### PR TITLE
Fix print error bug in startup sequence

### DIFF
--- a/src/pacmod_game_control_node.cpp
+++ b/src/pacmod_game_control_node.cpp
@@ -452,7 +452,7 @@ int main(int argc, char *argv[]) {
     if (controller_type != 0 &&
         controller_type != 1)
     {
-      ROS_INFO("steering_axis is invalid");
+      ROS_INFO("controller_type is invalid");
       willExit = true;
     }
   }


### PR DESCRIPTION
Prior to this commit there was a print error bug in the startup sequence for this node. This commit fixes the print error.