### PR TITLE
Fix typo in state check

### DIFF
--- a/src/pacmod_game_control_node.cpp
+++ b/src/pacmod_game_control_node.cpp
@@ -203,7 +203,7 @@ void callback_joy(const sensor_msgs::Joy::ConstPtr& msg)
     if (last_axes.empty() ||
           (last_axes[7] != msg->axes[7] ||
            last_axes[6] != msg->axes[6] ||
-           last_axes[2] != last_axes[2]))
+           last_axes[2] != msg->axes[2]))
       turn_signal_cmd_pub.publish(turn_signal_cmd_pub_msg);
 
     // Shifting: reverse


### PR DESCRIPTION
Prior to this commit there was a typo in the state check for turn signals. This commit fixes that typo.