### PR TITLE
Adding Support for XBox One Controller

### DIFF
--- a/src/pacmod_game_control_node.cpp
+++ b/src/pacmod_game_control_node.cpp
@@ -74,7 +74,8 @@ enum GamepadType
   LOGITECH_F310,
   HRI_SAFE_REMOTE,
   LOGITECH_G29,
-  NINTENDO_SWITCH_WIRED_PLUS
+  NINTENDO_SWITCH_WIRED_PLUS,
+  XBOX_ONE
 };
 
 enum JoyAxis
@@ -512,9 +513,9 @@ int main(int argc, char *argv[])
   {
     ROS_INFO("Got controller_type: %s", controller_string.c_str());
 
-    if (controller_string == "LOGITECH_F310")
+    if (controller_string == "LOGITECH_F310" || controller_string == "XBOX_ONE")
     {
-      controller = LOGITECH_F310;
+      controller = (controller_string == "LOGITECH_F310") ? LOGITECH_F310 : XBOX_ONE;
 
       axes[LEFT_STICK_LR] = 0;
       axes[LEFT_TRIGGER_AXIS] = 2;


### PR DESCRIPTION
This PR enables the use of the XBox One controller with pacmod_game_control.
The XBox One controller uses the same button layout as the Logitech F310, which simplifies
the code. Additionally, it should be noted that the XBox controller must be plugged
into the computer using a USB to Micro USB cable.