### PR TITLE
Adding enable/disable debounce for listening to PACMod feedback.

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -98,6 +98,7 @@ struct EnumHash
 };
 
 // static constants
+static const uint8_t STATE_CHANGE_DEBOUNCE_THRESHOLD = 4;
 static const float ROT_RANGE_SCALER_LB = 0.05;
 static const float ACCEL_SCALE_FACTOR = 0.6;
 static const float ACCEL_OFFSET = 0.21;
@@ -118,6 +119,7 @@ static const uint16_t BUTTON_DOWN = 1;
 // mutex
 static std::mutex enable_mutex;
 static std::mutex speed_mutex;
+static std::mutex state_change_mutex;
 
 }
 }

--- a/include/publish_control.h
+++ b/include/publish_control.h
@@ -38,6 +38,8 @@ public:
   static std::unordered_map<JoyButton, int, EnumHash> btns;
   static pacmod_msgs::VehicleSpeedRpt::ConstPtr last_speed_rpt;
   static bool pacmod_enable;
+  static bool recent_state_change;
+  static uint8_t state_change_debounce_count;
   
 private:
 

--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -71,6 +71,11 @@ bool PublishControlBoardRev2::check_is_enabled(const sensor_msgs::Joy::ConstPtr&
       bool_pub_msg.data = true;
       local_enable = true;
       enable_pub.publish(bool_pub_msg);
+
+      state_change_mutex.lock();
+      recent_state_change = true;
+      state_change_debounce_count = 0;
+      state_change_mutex.unlock();
     }
 
     // Disable
@@ -80,6 +85,11 @@ bool PublishControlBoardRev2::check_is_enabled(const sensor_msgs::Joy::ConstPtr&
       bool_pub_msg.data = false;
       local_enable = false;
       enable_pub.publish(bool_pub_msg);
+
+      state_change_mutex.lock();
+      recent_state_change = true;
+      state_change_debounce_count = 0;
+      state_change_mutex.unlock();
     }    
   }
   else
@@ -87,11 +97,15 @@ bool PublishControlBoardRev2::check_is_enabled(const sensor_msgs::Joy::ConstPtr&
     // Enable
     if (msg->buttons[btns[START_PLUS]] == BUTTON_DOWN)
     {
-    
       std_msgs::Bool bool_pub_msg;
       bool_pub_msg.data = true;
       local_enable = true;
       enable_pub.publish(bool_pub_msg);
+
+      state_change_mutex.lock();
+      recent_state_change = true;
+      state_change_debounce_count = 0;
+      state_change_mutex.unlock();
     }
 
     // Disable
@@ -101,6 +115,11 @@ bool PublishControlBoardRev2::check_is_enabled(const sensor_msgs::Joy::ConstPtr&
       bool_pub_msg.data = false;
       local_enable = false;
       enable_pub.publish(bool_pub_msg);
+
+      state_change_mutex.lock();
+      recent_state_change = true;
+      state_change_debounce_count = 0;
+      state_change_mutex.unlock();
     }
   }
 


### PR DESCRIPTION
When enabling or disabling via joystick, the global_enable variable
can be inadvertently overwritten by a new global report being
received with a stale value. This commit adds a debounce which causes the
joystick application to stop listening to the global report for N messages
after a state change.

This is helpful on PACMod 2 and required on PACMod 3.