### PR TITLE
Fixing threading problem with pacmod_enable.

### DIFF
--- a/include/publish_control.h
+++ b/include/publish_control.h
@@ -43,7 +43,7 @@ public:
 
 protected:
 
-  virtual bool check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg);
+  virtual void check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg);
 
   // ROS node handle
   ros::NodeHandle n;
@@ -67,6 +67,9 @@ protected:
   // state vectors
   std::vector<float> last_axes;
   std::vector<int> last_buttons;
+
+  // Other Variables
+  static bool local_enable;
   static bool recent_state_change;
   static uint8_t state_change_debounce_count;
   

--- a/include/publish_control.h
+++ b/include/publish_control.h
@@ -66,15 +66,6 @@ class PublishControl
     std::vector<float> last_axes;
     std::vector<int> last_buttons;
 
-    // ROS subscribers
-    ros::Subscriber joy_sub;
-    ros::Subscriber speed_sub;
-    ros::Subscriber enable_sub;
-
-    // state vectors
-    std::vector<float> last_axes;
-    std::vector<int> last_buttons;
-
     // Other Variables
     static bool local_enable;
     static bool recent_state_change;

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -23,6 +23,7 @@ std::unordered_map<JoyButton, int, EnumHash> PublishControl::btns;
 pacmod_msgs::VehicleSpeedRpt::ConstPtr PublishControl::last_speed_rpt = NULL;
 bool PublishControl::pacmod_enable;
 bool PublishControl::prev_enable = false;
+bool PublishControl::local_enable = false;
 bool PublishControl::recent_state_change = false;
 uint8_t PublishControl::state_change_debounce_count = 0;
 
@@ -45,8 +46,9 @@ void PublishControl::callback_control(const sensor_msgs::Joy::ConstPtr& msg)
   try
   {
     // Only send messages when enabled, or when the state changes between enabled/disabled
-    bool curr_enable = check_is_enabled(msg);
-    if (curr_enable == true || curr_enable != prev_enable)
+    check_is_enabled(msg);
+
+    if (local_enable == true || local_enable != prev_enable)
     {
       // Steering
       publish_steering_message(msg);
@@ -66,7 +68,8 @@ void PublishControl::callback_control(const sensor_msgs::Joy::ConstPtr& msg)
       // Lights and horn
       publish_lights_horn_wipers_message(msg);
     }
-    prev_enable = curr_enable;
+
+    prev_enable = local_enable;
   }
   catch (const std::out_of_range& oor)
   {
@@ -111,9 +114,9 @@ void PublishControl::callback_veh_speed(const pacmod_msgs::VehicleSpeedRpt::Cons
   speed_mutex.unlock();
 }
 
-bool PublishControl::check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg)
+void PublishControl::check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg)
 {
-  bool local_enable = false;
+  bool state_changed = false;
 
   enable_mutex.lock();
   local_enable = pacmod_enable;
@@ -122,48 +125,52 @@ bool PublishControl::check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg)
   if (controller == HRI_SAFE_REMOTE)
   {
     // Enable
-    if (msg->axes[axes[DPAD_UD]] >= 0.9)
+    if (msg->axes[axes[DPAD_UD]] >= 0.9 && !local_enable)
     {
       std_msgs::Bool bool_pub_msg;
       bool_pub_msg.data = true;
       local_enable = true;
       enable_pub.publish(bool_pub_msg);
+      state_changed = true;
     }
 
     // Disable
-    if (msg->axes[axes[DPAD_UD]] <= -0.9)
+    if (msg->axes[axes[DPAD_UD]] <= -0.9 && local_enable)
     {
       std_msgs::Bool bool_pub_msg;
       bool_pub_msg.data = false;
       local_enable = false;
       enable_pub.publish(bool_pub_msg);
+      state_changed = true;
     }
   }
   else
   {
     // Enable
-    if (msg->buttons[btns[START_PLUS]] == BUTTON_DOWN)
+    if (msg->buttons[btns[START_PLUS]] == BUTTON_DOWN && !local_enable)
     {
-
       std_msgs::Bool bool_pub_msg;
       bool_pub_msg.data = true;
       local_enable = true;
       enable_pub.publish(bool_pub_msg);
+      state_changed = true;
     }
 
     // Disable
-    if (msg->buttons[btns[BACK_SELECT_MINUS]] == BUTTON_DOWN)
+    if (msg->buttons[btns[BACK_SELECT_MINUS]] == BUTTON_DOWN && local_enable)
     {
       std_msgs::Bool bool_pub_msg;
       bool_pub_msg.data = false;
       local_enable = false;
       enable_pub.publish(bool_pub_msg);
+      state_changed = true;
     }
   }
 
-  enable_mutex.lock();
-  pacmod_enable = local_enable;
-  enable_mutex.unlock();
-
-  return local_enable;
+  if (state_changed)
+  {
+    enable_mutex.lock();
+    pacmod_enable = local_enable;
+    enable_mutex.unlock();
+  }
 }

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -52,12 +52,12 @@ void PublishControlBoardRev3::publish_steering_message(const sensor_msgs::Joy::C
   // Axis 0 is left thumbstick, axis 3 is right. Speed in rad/sec.
   pacmod_msgs::SteerSystemCmd steer_msg;
 
-  steer_msg.enable = pacmod_enable;
+  steer_msg.enable = local_enable;
 
   steer_msg.ignore_overrides = false;
 
   // If the enable flag just went to true, send an override clear
-  if (!prev_enable && pacmod_enable)
+  if (!prev_enable && local_enable)
     steer_msg.clear_override = true;
 
   float range_scale = fabs(msg->axes[axes[steering_axis]]) * (STEER_OFFSET - ROT_RANGE_SCALER_LB) + ROT_RANGE_SCALER_LB;
@@ -89,19 +89,19 @@ void PublishControlBoardRev3::publish_turn_signal_message(const sensor_msgs::Joy
 {
   pacmod_msgs::SystemCmdInt turn_signal_cmd_pub_msg;
 
-  turn_signal_cmd_pub_msg.enable = pacmod_enable;
+  turn_signal_cmd_pub_msg.enable = local_enable;
 
   turn_signal_cmd_pub_msg.ignore_overrides = false;
 
   // If the enable flag just went to true, send an override clear
-  if (!prev_enable && pacmod_enable)
+  if (!prev_enable && local_enable)
     turn_signal_cmd_pub_msg.clear_override = true;
   
   if (msg->axes[axes[DPAD_LR]] == AXES_MAX)
     turn_signal_cmd_pub_msg.command = SIGNAL_LEFT;
   else if (msg->axes[axes[DPAD_LR]] == AXES_MIN)
     turn_signal_cmd_pub_msg.command = SIGNAL_RIGHT;
-  else if (pacmod_enable != prev_enable)
+  else if (local_enable != prev_enable)
     turn_signal_cmd_pub_msg.command = last_turn_cmd;
   else
     turn_signal_cmd_pub_msg.command = SIGNAL_OFF;
@@ -114,7 +114,7 @@ void PublishControlBoardRev3::publish_turn_signal_message(const sensor_msgs::Joy
 
     if ((last_axes.empty() ||
         last_axes[2] != msg->axes[2]) ||
-        (pacmod_enable != prev_enable))
+        (local_enable != prev_enable))
       turn_signal_cmd_pub.publish(turn_signal_cmd_pub_msg);
   }
   else
@@ -125,7 +125,7 @@ void PublishControlBoardRev3::publish_turn_signal_message(const sensor_msgs::Joy
     if ((last_axes.empty() ||
         last_axes[axes[DPAD_LR]] != msg->axes[axes[DPAD_LR]] ||
         last_axes[axes[DPAD_UD]] != msg->axes[axes[DPAD_UD]]) ||
-        (pacmod_enable != prev_enable))
+        (local_enable != prev_enable))
     {
       turn_signal_cmd_pub.publish(turn_signal_cmd_pub_msg);
     }
@@ -138,10 +138,10 @@ void PublishControlBoardRev3::publish_shifting_message(const sensor_msgs::Joy::C
   if (msg->buttons[btns[RIGHT_BTN]] == BUTTON_DOWN)
   {
     pacmod_msgs::SystemCmdInt shift_cmd_pub_msg;
-    shift_cmd_pub_msg.enable = pacmod_enable;
+    shift_cmd_pub_msg.enable = local_enable;
     shift_cmd_pub_msg.ignore_overrides = false;
     // If the enable flag just went to true, send an override clear
-    if (!prev_enable && pacmod_enable)
+    if (!prev_enable && local_enable)
       shift_cmd_pub_msg.clear_override = true;
     shift_cmd_pub_msg.command = SHIFT_REVERSE;
     shift_cmd_pub.publish(shift_cmd_pub_msg);
@@ -151,10 +151,10 @@ void PublishControlBoardRev3::publish_shifting_message(const sensor_msgs::Joy::C
   if (msg->buttons[btns[BOTTOM_BTN]] == BUTTON_DOWN)
   {
     pacmod_msgs::SystemCmdInt shift_cmd_pub_msg;
-    shift_cmd_pub_msg.enable = pacmod_enable;
+    shift_cmd_pub_msg.enable = local_enable;
     shift_cmd_pub_msg.ignore_overrides = false;
     // If the enable flag just went to true, send an override clear
-    if (!prev_enable && pacmod_enable)
+    if (!prev_enable && local_enable)
       shift_cmd_pub_msg.clear_override = true;
     shift_cmd_pub_msg.command = SHIFT_LOW;
     shift_cmd_pub.publish(shift_cmd_pub_msg);
@@ -164,10 +164,10 @@ void PublishControlBoardRev3::publish_shifting_message(const sensor_msgs::Joy::C
   if (msg->buttons[btns[TOP_BTN]] == BUTTON_DOWN)
   {
     pacmod_msgs::SystemCmdInt shift_cmd_pub_msg;
-    shift_cmd_pub_msg.enable = pacmod_enable;
+    shift_cmd_pub_msg.enable = local_enable;
     shift_cmd_pub_msg.ignore_overrides = false;
     // If the enable flag just went to true, send an override clear
-    if (!prev_enable && pacmod_enable)
+    if (!prev_enable && local_enable)
       shift_cmd_pub_msg.clear_override = true;
     shift_cmd_pub_msg.command = SHIFT_PARK;
     shift_cmd_pub.publish(shift_cmd_pub_msg);
@@ -177,23 +177,23 @@ void PublishControlBoardRev3::publish_shifting_message(const sensor_msgs::Joy::C
   if (msg->buttons[btns[LEFT_BTN]] == BUTTON_DOWN)
   {
     pacmod_msgs::SystemCmdInt shift_cmd_pub_msg;
-    shift_cmd_pub_msg.enable = pacmod_enable;
+    shift_cmd_pub_msg.enable = local_enable;
     shift_cmd_pub_msg.ignore_overrides = false;
     // If the enable flag just went to true, send an override clear
-    if (!prev_enable && pacmod_enable)
+    if (!prev_enable && local_enable)
       shift_cmd_pub_msg.clear_override = true;
     shift_cmd_pub_msg.command = SHIFT_NEUTRAL;
     shift_cmd_pub.publish(shift_cmd_pub_msg);
   }
 
   // If only an enable/disable button was pressed
-  if (pacmod_enable != prev_enable)
+  if (local_enable != prev_enable)
   {
     pacmod_msgs::SystemCmdInt shift_cmd_pub_msg;
-    shift_cmd_pub_msg.enable = pacmod_enable;
+    shift_cmd_pub_msg.enable = local_enable;
     shift_cmd_pub_msg.ignore_overrides = false;
     // If the enable flag just went to true, send an override clear
-    if (!prev_enable && pacmod_enable)
+    if (!prev_enable && local_enable)
       shift_cmd_pub_msg.clear_override = true;
     shift_cmd_pub_msg.command = last_shift_cmd;
     shift_cmd_pub.publish(shift_cmd_pub_msg);
@@ -205,12 +205,12 @@ void PublishControlBoardRev3::publish_accelerator_message(const sensor_msgs::Joy
   pacmod_msgs::SystemCmdFloat accelerator_cmd_pub_msg;
   bool enable_accel;
 
-  accelerator_cmd_pub_msg.enable = pacmod_enable;
+  accelerator_cmd_pub_msg.enable = local_enable;
 
   accelerator_cmd_pub_msg.ignore_overrides = false;
 
   // If the enable flag just went to true, send an override clear
-  if (!prev_enable && pacmod_enable)
+  if (!prev_enable && local_enable)
     accelerator_cmd_pub_msg.clear_override = true;
 
   if (controller == HRI_SAFE_REMOTE)
@@ -270,12 +270,12 @@ void PublishControlBoardRev3::publish_brake_message(const sensor_msgs::Joy::Cons
   pacmod_msgs::SystemCmdFloat brake_msg;
   bool enable_brake;
 
-  brake_msg.enable = pacmod_enable;
+  brake_msg.enable = local_enable;
 
   brake_msg.ignore_overrides = false;
 
   // If the enable flag just went to true, send an override clear
-  if (!prev_enable && pacmod_enable)
+  if (!prev_enable && local_enable)
     brake_msg.clear_override = true;
 
   if (controller == HRI_SAFE_REMOTE)
@@ -331,10 +331,10 @@ void PublishControlBoardRev3::publish_lights_horn_wipers_message(const sensor_ms
         headlight_state = HEADLIGHT_STATE_START_VALUE;
 
       pacmod_msgs::SystemCmdInt headlight_cmd_pub_msg;
-      headlight_cmd_pub_msg.enable = pacmod_enable;
+      headlight_cmd_pub_msg.enable = local_enable;
       headlight_cmd_pub_msg.ignore_overrides = false;
       // If the enable flag just went to true, send an override clear
-      if (!prev_enable && pacmod_enable)
+      if (!prev_enable && local_enable)
         headlight_cmd_pub_msg.clear_override = true;
       headlight_cmd_pub_msg.command = headlight_state;
       headlight_cmd_pub.publish(headlight_cmd_pub_msg);
@@ -342,10 +342,10 @@ void PublishControlBoardRev3::publish_lights_horn_wipers_message(const sensor_ms
 
     // Horn
     pacmod_msgs::SystemCmdBool horn_cmd_pub_msg;
-    horn_cmd_pub_msg.enable = pacmod_enable;
+    horn_cmd_pub_msg.enable = local_enable;
     horn_cmd_pub_msg.ignore_overrides = false;
     // If the enable flag just went to true, send an override clear
-    if (!prev_enable && pacmod_enable)
+    if (!prev_enable && local_enable)
       horn_cmd_pub_msg.clear_override = true;
     if (msg->buttons[7] == 1)
       horn_cmd_pub_msg.command = 1;
@@ -367,10 +367,10 @@ void PublishControlBoardRev3::publish_lights_horn_wipers_message(const sensor_ms
         wiper_state = WIPER_STATE_START_VALUE;
 
       pacmod_msgs::SystemCmdInt wiper_cmd_pub_msg;
-      wiper_cmd_pub_msg.enable = pacmod_enable;
+      wiper_cmd_pub_msg.enable = local_enable;
       wiper_cmd_pub_msg.ignore_overrides = false;
       // If the enable flag just went to true, send an override clear
-      if (!prev_enable && pacmod_enable)
+      if (!prev_enable && local_enable)
         wiper_cmd_pub_msg.clear_override = true;
       wiper_cmd_pub_msg.command = wiper_state;
       wiper_cmd_pub.publish(wiper_cmd_pub_msg);


### PR DESCRIPTION
The pacmod_enable variable can be modified in two separate threads:
the callback for joy (in the case of a user-initiated enable/disable)
or the callback for the PACMod's enable status topic (in case of an
override or other disable). This necessitates having a "local" copy
of the enable state through the publishing process to keep from having
to lock/unlock a mutex every time we need the current enable/disable
state. This commit converts the "local_enable" variable to one that
is attached to PublishControl and is only updated on a joy callback.