### PR TITLE
TESTED - Removes state_change_debounce. No longer necessary.

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -97,7 +97,6 @@ struct EnumHash
 };
 
 // static constants
-static const uint8_t STATE_CHANGE_DEBOUNCE_THRESHOLD = 4;
 static const float ROT_RANGE_SCALER_LB = 0.05;
 static const float ACCEL_SCALE_FACTOR = 0.6;
 static const float ACCEL_OFFSET = 0.21;

--- a/include/publish_control.h
+++ b/include/publish_control.h
@@ -39,6 +39,7 @@ class PublishControl
     static pacmod_msgs::VehicleSpeedRpt::ConstPtr last_speed_rpt;
     static bool pacmod_enable;
     static bool prev_enable;
+    static bool last_pacmod_state;
 
   protected:
     virtual void check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg);


### PR DESCRIPTION
We really only care about the transition of PACMod from enabled
to disabled and when this transition happens, it should not be
ignored no matter how recently a state transition has happened
in the game control node. This implements this logic.