### PR TITLE
TESTED - PACMod 2 and PACMod 3 use different topics for enabled feedback.

### DIFF
--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -32,7 +32,6 @@ PublishControl::PublishControl()
   // Subscribe to messages
   joy_sub = n.subscribe("joy", 1000, &PublishControl::callback_control, this);
   speed_sub = n.subscribe("/pacmod/parsed_tx/vehicle_speed_rpt", 20, &PublishControl::callback_veh_speed);
-  enable_sub = n.subscribe("/pacmod/as_tx/enable", 20, &PublishControl::callback_pacmod_enable);
 
   // Advertise published messages
   enable_pub = n.advertise<std_msgs::Bool>("/pacmod/as_rx/enable", 20);

--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -16,6 +16,9 @@ using namespace AS::Joystick;
 PublishControlBoardRev2::PublishControlBoardRev2() :
   PublishControl()
 {
+  // Subscribe to messages
+  enable_sub = n.subscribe("/pacmod/as_tx/enable", 20, &PublishControl::callback_pacmod_enable);
+
   // Advertise published messages
   turn_signal_cmd_pub = n.advertise<pacmod_msgs::PacmodCmd>("/pacmod/as_rx/turn_cmd", 20);
   headlight_cmd_pub = n.advertise<pacmod_msgs::PacmodCmd>("/pacmod/as_rx/headlight_cmd", 20);

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -16,6 +16,7 @@ PublishControlBoardRev3::PublishControlBoardRev3() :
   PublishControl()
 {
   // Subscribe to messages
+  enable_sub = n.subscribe("/pacmod/as_tx/enabled", 20, &PublishControl::callback_pacmod_enable);
   shift_sub = n.subscribe("/pacmod/parsed_tx/shift_rpt", 20, &PublishControlBoardRev3::callback_shift_rpt);
   turn_sub = n.subscribe("/pacmod/parsed_tx/turn_rpt", 20, &PublishControlBoardRev3::callback_turn_rpt);
 


### PR DESCRIPTION
PACMod 2 uses the topic as_tx/enable while PACMod 3 uses
as_tx/enabled. This fixes this node for use with the enabled version.