### PR TITLE
Fixing regression with triggers as accel/brake - takeoff.

### DIFF
--- a/include/publish_control.h
+++ b/include/publish_control.h
@@ -40,6 +40,8 @@ class PublishControl
     static bool pacmod_enable;
     static bool prev_enable;
     static bool last_pacmod_state;
+    static bool accel_0_rcvd;
+    static bool brake_0_rcvd;
 
   protected:
     virtual void check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg);

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -25,6 +25,8 @@ bool PublishControl::pacmod_enable;
 bool PublishControl::prev_enable = false;
 bool PublishControl::local_enable = false;
 bool PublishControl::last_pacmod_state = false;
+bool PublishControl::accel_0_rcvd = false;
+bool PublishControl::brake_0_rcvd = false;
 
 PublishControl::PublishControl()
 {

--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -131,7 +131,6 @@ void PublishControlBoardRev2::publish_shifting_message(const sensor_msgs::Joy::C
 void PublishControlBoardRev2::publish_accelerator_message(const sensor_msgs::Joy::ConstPtr& msg)
 {
   pacmod_msgs::PacmodCmd accelerator_cmd_pub_msg;
-  bool enable_accel;
 
   if (controller == HRI_SAFE_REMOTE)
   {
@@ -146,9 +145,9 @@ void PublishControlBoardRev2::publish_accelerator_message(const sensor_msgs::Joy
   else if(controller == LOGITECH_G29)
   {
     if (msg->axes[axes[RIGHT_TRIGGER_AXIS]] != 0)
-      enable_accel = true;
+      PublishControl::accel_0_rcvd = true;
 
-    if (enable_accel)
+    if (PublishControl::accel_0_rcvd)
     {
       if ((vehicle_type == LEXUS_RX_450H) ||
           (vehicle_type == VEHICLE_4))
@@ -165,9 +164,9 @@ void PublishControlBoardRev2::publish_accelerator_message(const sensor_msgs::Joy
   else
   {
     if (msg->axes[axes[RIGHT_TRIGGER_AXIS]] != 0)
-      enable_accel = true;
+      PublishControl::accel_0_rcvd = true;
 
-    if (enable_accel)
+    if (PublishControl::accel_0_rcvd)
     {
       if ((vehicle_type == LEXUS_RX_450H) ||
           (vehicle_type == VEHICLE_4))
@@ -187,7 +186,6 @@ void PublishControlBoardRev2::publish_accelerator_message(const sensor_msgs::Joy
 void PublishControlBoardRev2::publish_brake_message(const sensor_msgs::Joy::ConstPtr& msg)
 {
   pacmod_msgs::PacmodCmd brake_msg;
-  bool enable_brake;
 
   if (controller == HRI_SAFE_REMOTE)
   {
@@ -196,9 +194,9 @@ void PublishControlBoardRev2::publish_brake_message(const sensor_msgs::Joy::Cons
   else if(controller == LOGITECH_G29)
   {
     if (msg->axes[axes[LEFT_TRIGGER_AXIS]] != 0)
-      enable_brake = true;
+      PublishControl::brake_0_rcvd = true;
 
-    if (enable_brake)
+    if (PublishControl::brake_0_rcvd)
       brake_msg.f64_cmd = ((msg->axes[axes[LEFT_TRIGGER_AXIS]] + 1.0) / 2.0) * brake_scale_val;
     else
       brake_msg.f64_cmd = 0;
@@ -206,9 +204,9 @@ void PublishControlBoardRev2::publish_brake_message(const sensor_msgs::Joy::Cons
   else
   {
     if (msg->axes[axes[LEFT_TRIGGER_AXIS]] != 0)
-      enable_brake = true;
+      PublishControl::brake_0_rcvd = true;
 
-    if (enable_brake)
+    if (PublishControl::brake_0_rcvd)
       brake_msg.f64_cmd = -((msg->axes[axes[LEFT_TRIGGER_AXIS]] - 1.0) / 2.0) * brake_scale_val;
     else
       brake_msg.f64_cmd = 0;

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -211,7 +211,6 @@ void PublishControlBoardRev3::publish_shifting_message(const sensor_msgs::Joy::C
 void PublishControlBoardRev3::publish_accelerator_message(const sensor_msgs::Joy::ConstPtr& msg)
 {
   pacmod_msgs::SystemCmdFloat accelerator_cmd_pub_msg;
-  bool enable_accel;
 
   accelerator_cmd_pub_msg.enable = local_enable;
   accelerator_cmd_pub_msg.ignore_overrides = false;
@@ -232,9 +231,9 @@ void PublishControlBoardRev3::publish_accelerator_message(const sensor_msgs::Joy
   else if(controller == LOGITECH_G29)
   {
     if (msg->axes[axes[RIGHT_TRIGGER_AXIS]] != 0)
-      enable_accel = true;
+      PublishControl::accel_0_rcvd = true;
 
-    if (enable_accel)
+    if (PublishControl::accel_0_rcvd)
     {
       if (vehicle_type == LEXUS_RX_450H ||
           vehicle_type == VEHICLE_4 ||
@@ -251,9 +250,9 @@ void PublishControlBoardRev3::publish_accelerator_message(const sensor_msgs::Joy
   else
   {
     if (msg->axes[axes[RIGHT_TRIGGER_AXIS]] != 0)
-      enable_accel = true;
+      PublishControl::accel_0_rcvd = true;
 
-    if (enable_accel)
+    if (PublishControl::accel_0_rcvd)
     {
       if (vehicle_type == LEXUS_RX_450H ||
           vehicle_type == VEHICLE_4 ||
@@ -274,7 +273,6 @@ void PublishControlBoardRev3::publish_accelerator_message(const sensor_msgs::Joy
 void PublishControlBoardRev3::publish_brake_message(const sensor_msgs::Joy::ConstPtr& msg)
 {
   pacmod_msgs::SystemCmdFloat brake_msg;
-  bool enable_brake;
 
   brake_msg.enable = local_enable;
   brake_msg.ignore_overrides = false;
@@ -290,9 +288,9 @@ void PublishControlBoardRev3::publish_brake_message(const sensor_msgs::Joy::Cons
   else if(controller == LOGITECH_G29)
   {
     if (msg->axes[axes[LEFT_TRIGGER_AXIS]] != 0)
-      enable_brake = true;
+      PublishControl::brake_0_rcvd = true;
 
-    if (enable_brake)
+    if (PublishControl::brake_0_rcvd)
     {
       brake_msg.command = ((msg->axes[axes[LEFT_TRIGGER_AXIS]] + 1.0) / 2.0) * brake_scale_val;
     }
@@ -304,9 +302,9 @@ void PublishControlBoardRev3::publish_brake_message(const sensor_msgs::Joy::Cons
   else
   {
     if (msg->axes[axes[LEFT_TRIGGER_AXIS]] != 0)
-      enable_brake = true;
+      PublishControl::brake_0_rcvd = true;
 
-    if (enable_brake)
+    if (PublishControl::brake_0_rcvd)
     {
       brake_msg.command = -((msg->axes[axes[LEFT_TRIGGER_AXIS]] - 1.0) / 2.0) * brake_scale_val;
     }


### PR DESCRIPTION
During the reorganization of code into publish_control, a
regression bug was introduced involving the joystick trigger
initial values. This commit fixes that bug.