### PR TITLE
Added 1-to-1 steering control between the G29 wheel & the vehicle's wheel.

### DIFF
--- a/launch/pacmod_game_control.launch
+++ b/launch/pacmod_game_control.launch
@@ -12,9 +12,9 @@
        1: Polaris Ranger
        2: Lexus RX 450H
        3: International Prostar+ 122 -->
-  <arg name="vehicle_type" default="0"/>
+  <arg name="vehicle_type" default="2"/>
 
-  <arg name="pacmod_can_hardware_id" default="12345" />
+  <arg name="pacmod_can_hardware_id" default="41316" />
   <arg name="pacmod_can_circuit_id" default="0" />
   <arg name="pacmod_socketcan_device" default="can0" />
 
@@ -23,7 +23,7 @@
        POLARIS_RANGER
        LEXUS_RX_450H
        INTERNATIONAL_PROSTAR_122 -->
-  <arg name="pacmod_vehicle_type" default="POLARIS_GEM" />
+  <arg name="pacmod_vehicle_type" default="LEXUS_RX_450H" />
     
   <arg name="steering_stick" default="LEFT"/>
 
@@ -74,6 +74,7 @@
       <param name="coalesce_interval" type="double" value="0.02"/>
       <param name="default_trig_val" value="true"/>
       <param name="dev" value="/dev/input/js0"/>
+      <param name="deadzone" value="0.0"/>
     </node>
 
     <node pkg="pacmod_game_control" type="pacmod_game_control_node" name="pacmod_game_control">

--- a/src/startup_checks.cpp
+++ b/src/startup_checks.cpp
@@ -135,7 +135,9 @@ bool AS::Joystick::check_controller_type(ros::NodeHandle * nodeH)
     else if (controller_string == "LOGITECH_G29")
     {
       PublishControl::controller = LOGITECH_G29;
-
+			
+			PublishControl::max_rot_rad = 7.85;
+			
       // steering wheel, not right stick
       PublishControl::axes[RIGHT_STICK_LR] = 0;
       // throttle pedal, not right trigger


### PR DESCRIPTION
Maps the max steering angle the Logitech G29 steering wheel can rotate, so that the vehicles steering wheel is one to one with the G29's wheel position.