### PR TITLE
Feat/lexus braking curve

### DIFF
--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -322,7 +322,15 @@ void PublishControlBoardRev3::publish_brake_message(const sensor_msgs::Joy::Cons
 
     if (PublishControl::brake_0_rcvd)
     {
-      brake_msg.command = -((msg->axes[axes[LEFT_TRIGGER_AXIS]] - 1.0) / 2.0) * brake_scale_val;
+      float brake_value = -((msg->axes[axes[LEFT_TRIGGER_AXIS]] - 1.0) / 2.0) * brake_scale_val;
+      if(vehicle_type == LEXUS_RX_450H)
+      {
+        brake_msg.command = fmin(pow(brake_value, 3) * 2 - pow(brake_value, 2) * 1.5 + brake_value * 6.25, 1.0F);
+      }
+      else
+      {
+        brake_msg.command = brake_value;
+      }
     }
     else
     {

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -325,7 +325,8 @@ void PublishControlBoardRev3::publish_brake_message(const sensor_msgs::Joy::Cons
       float brake_value = -((msg->axes[axes[LEFT_TRIGGER_AXIS]] - 1.0) / 2.0) * brake_scale_val;
       if(vehicle_type == LEXUS_RX_450H)
       {
-        brake_msg.command = fmin(pow(brake_value, 3) * 2 - pow(brake_value, 2) * 1.5 + brake_value * 6.25, 1.0F);
+        // These constants came from playing around in excel until stuff looked good. Seems to work okay
+        brake_msg.command = fmin(pow(brake_value, 3) * 2.0F - pow(brake_value, 2) * 1.5F + brake_value * 0.625F, 1.0F);
       }
       else
       {


### PR DESCRIPTION
Added cubic smoothing for the brakes, in the hopes of making the Lexus easier to drive with the gamepad.

Before: brakes were applied linearly, and quickly passed out of the "comfortable braking zone" and into the "teeth in the steering wheel" braking zone. 

After: It takes more movement on the controller to reach higher braking force, but you can still get to 100% by fully depressing the trigger.