### PR TITLE
Maint/hri remap part two

### DIFF
--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -62,19 +62,17 @@ void PublishControlBoardRev2::publish_steering_message(const sensor_msgs::Joy::C
 void PublishControlBoardRev2::publish_turn_signal_message(const sensor_msgs::Joy::ConstPtr& msg)
 {
   pacmod_msgs::PacmodCmd turn_signal_cmd_pub_msg;
-  
-  if (msg->axes[axes[DPAD_LR]] == AXES_MAX)
-    turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_LEFT;
-  else if (msg->axes[axes[DPAD_LR]] == AXES_MIN)
-    turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_RIGHT;
-  else
-    turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_OFF;
-
   // Hazard lights (both left and right turn signals)
   if (controller == HRI_SAFE_REMOTE)
   {
     if(msg->axes[2] < -0.5)
       turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_HAZARD;
+    else if(msg->axes[5] > 0.5)
+      turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_LEFT;
+    else if(msg->axes[5] < -0.5)
+      turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_RIGHT;
+    else
+      turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_OFF;
 
     if (last_axes.empty() || last_axes[2] != msg->axes[2])
       turn_signal_cmd_pub.publish(turn_signal_cmd_pub_msg);
@@ -83,6 +81,12 @@ void PublishControlBoardRev2::publish_turn_signal_message(const sensor_msgs::Joy
   {
     if (msg->axes[axes[DPAD_UD]] == AXES_MIN)
       turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_HAZARD;
+    else if (msg->axes[axes[DPAD_LR]] == AXES_MAX)
+      turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_LEFT;
+    else if (msg->axes[axes[DPAD_LR]] == AXES_MIN)
+      turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_RIGHT;
+    else
+      turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_OFF;
 
     if (last_axes.empty() ||
         last_axes[axes[DPAD_LR]] != msg->axes[axes[DPAD_LR]] ||

--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -65,6 +65,8 @@ void PublishControlBoardRev2::publish_turn_signal_message(const sensor_msgs::Joy
   // Hazard lights (both left and right turn signals)
   if (controller == HRI_SAFE_REMOTE)
   {
+    // Axis 2 is the "left trigger" and axis 5 is the "right trigger" single
+    // axis joysticks on the back of the controller
     if(msg->axes[2] < -0.5)
       turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_HAZARD;
     else if(msg->axes[5] > 0.5)

--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -74,7 +74,7 @@ void PublishControlBoardRev2::publish_turn_signal_message(const sensor_msgs::Joy
     else
       turn_signal_cmd_pub_msg.ui16_cmd = SIGNAL_OFF;
 
-    if (last_axes.empty() || last_axes[2] != msg->axes[2])
+    if (last_axes.empty() || last_axes[2] != msg->axes[2] || last_axes[5] != msg->axes[5])
       turn_signal_cmd_pub.publish(turn_signal_cmd_pub_msg);
   }
   else

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -109,6 +109,8 @@ void PublishControlBoardRev3::publish_turn_signal_message(const sensor_msgs::Joy
   // Hazard lights (both left and right turn signals), and HRI support
   if (controller == HRI_SAFE_REMOTE)
   {
+    // Axis 2 is the "left trigger" and axis 5 is the "right trigger" single
+    // axis joysticks on the back of the controller
     if(msg->axes[2] < -0.5)
       turn_signal_cmd_pub_msg.command = SIGNAL_HAZARD;
     else if(msg->axes[5] > 0.5)

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -142,7 +142,7 @@ void PublishControlBoardRev3::publish_turn_signal_message(const sensor_msgs::Joy
     else
       turn_signal_cmd_pub_msg.command = SIGNAL_OFF;
 
-    if ((last_axes.empty() ||
+    if (last_axes.empty() ||
         last_axes[axes[DPAD_LR]] != msg->axes[axes[DPAD_LR]] ||
         last_axes[axes[DPAD_UD]] != msg->axes[axes[DPAD_UD]] ||
         local_enable != prev_enable)


### PR DESCRIPTION
PR #53 accidentally overlapped some buttons. This moves the turn signals to the unused axis.