### PR TITLE
Fix/speed limit - clipped steer rate limit 

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pacmod_game_control</name>
-  <version>2.3.1</version>
+  <version>2.3.0</version>
   <description>ROS Package for controlling the AStuff PACMod with a Joystick</description>
   <license>MIT</license>
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pacmod_game_control</name>
-  <version>2.3.0</version>
+  <version>2.3.1</version>
   <description>ROS Package for controlling the AStuff PACMod with a Joystick</description>
   <license>MIT</license>
 

--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -56,9 +56,9 @@ void PublishControlBoardRev2::publish_steering_message(const sensor_msgs::Joy::C
   if (speed_valid)
     if (current_speed < max_veh_speed)
       speed_scale = STEER_OFFSET - fabs(
-        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // if max_veh_speed is set incorrectly this will go negative.
+        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // this could go negative.
     else
-       speed_scale = 0.33333;   //clips the equation assuming 1 offset and 1.5 scale_factor
+       speed_scale = 0.33333;   // clips the equation assuming 1 offset and 1.5 scale_factor
 
   steer_msg.angular_position = (range_scale * max_rot_rad) * msg->axes[axes[steering_axis]];
   steer_msg.angular_velocity_limit = steering_max_speed * speed_scale;

--- a/src/publish_control_board_rev2.cpp
+++ b/src/publish_control_board_rev2.cpp
@@ -54,8 +54,11 @@ void PublishControlBoardRev2::publish_steering_message(const sensor_msgs::Joy::C
   speed_mutex.unlock();
 
   if (speed_valid)
-    speed_scale = STEER_OFFSET - fabs(
-        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // Never want to reach 0 speed scale.
+    if (current_speed < max_veh_speed)
+      speed_scale = STEER_OFFSET - fabs(
+        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // if max_veh_speed is set incorrectly this will go negative.
+    else
+       speed_scale = 0.33333;   //clips the equation assuming 1 offset and 1.5 scale_factor
 
   steer_msg.angular_position = (range_scale * max_rot_rad) * msg->axes[axes[steering_axis]];
   steer_msg.angular_velocity_limit = steering_max_speed * speed_scale;

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -87,10 +87,10 @@ void PublishControlBoardRev3::publish_steering_message(const sensor_msgs::Joy::C
   if (speed_valid)
     if (current_speed < max_veh_speed)
       speed_scale = STEER_OFFSET - fabs(
-        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // if max_veh_speed is set incorrectly this will go negative.
+        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // this could go negative.
     else
-       speed_scale = 0.33333;   //clips the equation assuming 1 offset and 1.5 scale_factor
-        
+       speed_scale = 0.33333;  // clips the equation assuming 1 offset and 1.5 scale_factor
+  
   steer_msg.command = (range_scale * max_rot_rad) * msg->axes[axes[steering_axis]];
   steer_msg.rotation_rate = steering_max_speed * speed_scale;
   steering_set_position_with_speed_limit_pub.publish(steer_msg);

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -90,7 +90,7 @@ void PublishControlBoardRev3::publish_steering_message(const sensor_msgs::Joy::C
         (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // this could go negative.
     else
        speed_scale = 0.33333;  // clips the equation assuming 1 offset and 1.5 scale_factor
-  
+
   steer_msg.command = (range_scale * max_rot_rad) * msg->axes[axes[steering_axis]];
   steer_msg.rotation_rate = steering_max_speed * speed_scale;
   steering_set_position_with_speed_limit_pub.publish(steer_msg);

--- a/src/publish_control_board_rev3.cpp
+++ b/src/publish_control_board_rev3.cpp
@@ -85,9 +85,12 @@ void PublishControlBoardRev3::publish_steering_message(const sensor_msgs::Joy::C
   speed_mutex.unlock();
 
   if (speed_valid)
-    speed_scale = STEER_OFFSET - fabs(
-        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // Never want to reach 0 speed scale.
-
+    if (current_speed < max_veh_speed)
+      speed_scale = STEER_OFFSET - fabs(
+        (current_speed / (max_veh_speed * STEER_SCALE_FACTOR)));  // if max_veh_speed is set incorrectly this will go negative.
+    else
+       speed_scale = 0.33333;   //clips the equation assuming 1 offset and 1.5 scale_factor
+        
   steer_msg.command = (range_scale * max_rot_rad) * msg->axes[axes[steering_axis]];
   steer_msg.rotation_rate = steering_max_speed * speed_scale;
   steering_set_position_with_speed_limit_pub.publish(steer_msg);


### PR DESCRIPTION
steer rate limit would go negative if max vehicle speed was set incorrectly, added a minimum rate limit.