### PR TITLE
Controller Abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(pacmod_game_control_node
   src/pacmod_game_control_node.cpp
   src/startup_checks.cpp
   src/publish_control.cpp
+  src/controllers.cpp
 )
 
 add_dependencies(pacmod_game_control_node

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pacmod_game_control)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 find_package(catkin REQUIRED COMPONENTS
   roslint

--- a/include/pacmod_game_control/controllers.h
+++ b/include/pacmod_game_control/controllers.h
@@ -21,7 +21,7 @@ public:
   void set_controller_input(const sensor_msgs::Joy& joy_msg);
   virtual float get_accelerator_value();
   virtual float get_brake_value();
-  // virtual float get_steering_value();
+  virtual float get_steering_value(JoyAxis steering_axis);
   virtual int get_turn_signal_cmd();
   virtual int get_shift_cmd();
   virtual bool get_horn_cmd();

--- a/include/pacmod_game_control/controllers.h
+++ b/include/pacmod_game_control/controllers.h
@@ -18,17 +18,18 @@ class Controller
 {
 public:
   Controller();
+  virtual ~Controller();
   void set_controller_input(const sensor_msgs::Joy& joy_msg);
-  virtual float get_accelerator_value();
-  virtual float get_brake_value();
-  virtual float get_steering_value(JoyAxis steering_axis);
-  virtual int get_turn_signal_cmd();
-  virtual int get_shift_cmd();
-  virtual bool get_horn_cmd();
-  virtual bool get_headlight_change();
-  virtual bool get_wiper_change();
-  virtual bool get_enable();
-  virtual bool get_disable();
+  virtual float accelerator_value();
+  virtual float brake_value();
+  virtual float steering_value(JoyAxis steering_axis);
+  virtual int turn_signal_cmd();
+  virtual int shift_cmd();
+  virtual bool horn_cmd();
+  virtual bool headlight_change();
+  virtual bool wiper_change();
+  virtual bool enable();
+  virtual bool disable();
 
 protected:
   sensor_msgs::Joy input_msg_;
@@ -40,21 +41,21 @@ class LogitechG29Controller : public Controller
 {
 public:
   LogitechG29Controller();
-  float get_accelerator_value();
-  float get_brake_value();
+  float accelerator_value() override;
+  float brake_value() override;
 };
 
 class HriSafeController : public Controller
 {
 public:
   HriSafeController();
-  float get_accelerator_value();
-  float get_brake_value();
-  int get_turn_signal_cmd();
-  bool get_horn_cmd();
-  bool get_wiper_change();
-  bool get_enable();
-  bool get_disable();
+  float accelerator_value() override;
+  float brake_value() override;
+  int turn_signal_cmd() override;
+  bool horn_cmd() override;
+  bool wiper_change() override;
+  bool enable() override;
+  bool disable() override;
 };
 
 #endif  // PACMOD_GAME_CONTROL_CONTROLLERS_H

--- a/include/pacmod_game_control/controllers.h
+++ b/include/pacmod_game_control/controllers.h
@@ -1,0 +1,60 @@
+/*
+ * Unpublished Copyright (c) 2009-2021 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the PACMod ROS 1.0 driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
+
+#ifndef PACMOD_GAME_CONTROL_CONTROLLERS_H
+#define PACMOD_GAME_CONTROL_CONTROLLERS_H
+
+#include "pacmod_game_control/globals.h"
+
+#include <unordered_map>
+
+#include <sensor_msgs/Joy.h>
+
+class Controller
+{
+public:
+  Controller();
+  void set_controller_input(const sensor_msgs::Joy& joy_msg);
+  virtual float get_accelerator_value();
+  virtual float get_brake_value();
+  // virtual float get_steering_value();
+  virtual int get_turn_signal_cmd();
+  virtual int get_shift_cmd();
+  virtual bool get_horn_cmd();
+  virtual bool get_headlight_change();
+  virtual bool get_wiper_change();
+  virtual bool get_enable();
+  virtual bool get_disable();
+
+protected:
+  sensor_msgs::Joy input_msg_;
+  std::unordered_map<JoyAxis, int, EnumHash> axes_;
+  std::unordered_map<JoyButton, int, EnumHash> btns_;
+};
+
+class LogitechG29Controller : public Controller
+{
+public:
+  LogitechG29Controller();
+  float get_accelerator_value();
+  float get_brake_value();
+};
+
+class HriSafeController : public Controller
+{
+public:
+  HriSafeController();
+  float get_accelerator_value();
+  float get_brake_value();
+  int get_turn_signal_cmd();
+  bool get_horn_cmd();
+  bool get_wiper_change();
+  bool get_enable();
+  bool get_disable();
+};
+
+#endif  // PACMOD_GAME_CONTROL_CONTROLLERS_H

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -11,6 +11,8 @@
 #include "pacmod_game_control/globals.h"
 #include "pacmod_game_control/controllers.h"
 
+#include <limits>
+#include <memory>
 #include <vector>
 #include <unordered_map>
 

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -41,8 +41,6 @@ public:
   double accel_scale_val = 1.0;
   double brake_scale_val = 1.0;
   double steering_max_speed = INVALID;
-  std::unordered_map<JoyAxis, int, EnumHash> axes;
-  std::unordered_map<JoyButton, int, EnumHash> btns;
   pacmod_msgs::VehicleSpeedRpt::ConstPtr last_speed_rpt = NULL;
   bool pacmod_enable = false;
   bool prev_enable = false;

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -9,6 +9,7 @@
 #define PACMOD_GAME_CONTROL_PUBLISH_CONTROL_H
 
 #include "pacmod_game_control/globals.h"
+#include "pacmod_game_control/controllers.h"
 
 #include <vector>
 #include <unordered_map>
@@ -35,7 +36,7 @@ public:
   JoyAxis steering_axis = JoyAxis::LEFT_STICK_LR;
   float max_rot_rad = MAX_ROT_RAD_DEFAULT;
   VehicleType vehicle_type;
-  GamepadType controller = GamepadType::LOGITECH_F310;
+  GamepadType controller_type = GamepadType::LOGITECH_F310;
   double max_veh_speed = INVALID;
   double accel_scale_val = 1.0;
   double brake_scale_val = 1.0;
@@ -52,19 +53,18 @@ public:
   bool headlight_state_change = false;
   int wiper_state = 0;
   int last_shift_cmd = 0;
-  int last_turn_cmd = 0;
+  int turn_signal_rpt = pacmod_msgs::SystemRptInt::TURN_NONE;
   int last_rear_pass_door_cmd = 0;
   float last_brake_cmd = 0.0;
 
 private:
-  void check_is_enabled(const sensor_msgs::Joy::ConstPtr& msg);
+  void check_is_enabled();
   void publish_steering_message(const sensor_msgs::Joy::ConstPtr& msg);
-  void publish_turn_signal_message(const sensor_msgs::Joy::ConstPtr& msg);
-  void publish_rear_pass_door_message(const sensor_msgs::Joy::ConstPtr& msg);
-  void publish_shifting_message(const sensor_msgs::Joy::ConstPtr& msg);
+  void publish_turn_signal_message();
+  void publish_shifting_message();
   void publish_accelerator_message(const sensor_msgs::Joy::ConstPtr& msg);
   void publish_brake_message(const sensor_msgs::Joy::ConstPtr& msg);
-  void publish_lights_horn_wipers_message(const sensor_msgs::Joy::ConstPtr& msg);
+  void publish_lights_horn_wipers_message();
 
   // Startup checks
   bool run_startup_checks_error();
@@ -101,6 +101,7 @@ private:
   std::vector<int> last_buttons;
 
   // Other Variables
+  Controller* controller;
   bool local_enable;
   bool recent_state_change;
   uint8_t state_change_debounce_count;

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -47,8 +47,6 @@ public:
   bool pacmod_enable = false;
   bool prev_enable = false;
   bool last_pacmod_state = false;
-  bool accel_0_rcvd = false;
-  bool brake_0_rcvd = false;
   int headlight_state = 0;
   bool headlight_state_change = false;
   int wiper_state = 0;

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -37,10 +37,10 @@ public:
   float max_rot_rad = MAX_ROT_RAD_DEFAULT;
   VehicleType vehicle_type;
   GamepadType controller_type = GamepadType::LOGITECH_F310;
-  double max_veh_speed = INVALID;
-  double accel_scale_val = 1.0;
-  double brake_scale_val = 1.0;
-  double steering_max_speed = INVALID;
+  float max_veh_speed = std::numeric_limits<float>::quiet_NaN();
+  float accel_scale_val = 1.0;
+  float brake_scale_val = 1.0;
+  float steering_max_speed = std::numeric_limits<float>::quiet_NaN();
   pacmod_msgs::VehicleSpeedRpt::ConstPtr last_speed_rpt = NULL;
   bool pacmod_enable = false;
   bool prev_enable = false;
@@ -97,7 +97,7 @@ private:
   std::vector<int> last_buttons;
 
   // Other Variables
-  Controller* controller;
+  std::unique_ptr<Controller> controller;
   bool local_enable;
   bool recent_state_change;
   uint8_t state_change_debounce_count;

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -55,11 +55,11 @@ public:
 
 private:
   void check_is_enabled();
-  void publish_steering_message(const sensor_msgs::Joy::ConstPtr& msg);
+  void publish_steering_message();
   void publish_turn_signal_message();
   void publish_shifting_message();
-  void publish_accelerator_message(const sensor_msgs::Joy::ConstPtr& msg);
-  void publish_brake_message(const sensor_msgs::Joy::ConstPtr& msg);
+  void publish_accelerator_message();
+  void publish_brake_message();
   void publish_lights_horn_wipers_message();
 
   // Startup checks

--- a/launch/pacmod_game_control.launch
+++ b/launch/pacmod_game_control.launch
@@ -23,10 +23,9 @@
 
   <!-- Supported types are:
        LOGITECH_F310 (the standard gamepad provided with all vehicles)
+       XBOX_ONE (Xbox 360 controller works the same)
        HRI_SAFE_REMOTE
-       LOGITECH_G29 (steering wheel and pedals)
-       NINTENDO_SWITCH_WIRED_PLUS
-       XBOX_ONE -->
+       LOGITECH_G29 (steering wheel and pedals) -->
   <arg name="controller_type" default="LOGITECH_F310"/>
 
   <!-- 4.71239 is fast but jerky. Speed in rad/sec.-->

--- a/src/controllers.cpp
+++ b/src/controllers.cpp
@@ -152,7 +152,6 @@ bool Controller::get_disable()
           input_msg_.buttons[btns_[JoyButton::START_PLUS]] != BUTTON_DOWN);
 }
 
-
 // --- Logitech G29, racing wheel with pedals
 LogitechG29Controller::LogitechG29Controller()
 {
@@ -190,7 +189,6 @@ float LogitechG29Controller::get_brake_value()
   return (input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] + 1.0) / 2.0;
 }
 
-
 // --- HRI Safe Remote Controller
 HriSafeController::HriSafeController()
 {
@@ -220,7 +218,7 @@ float HriSafeController::get_accelerator_value()
   // Only consider center-to-up range as accelerator value
   if (input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]] <= 0.0)
   {
-    return  -(input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]]);
+    return -(input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]]);
   }
   return 0.0;
 }

--- a/src/controllers.cpp
+++ b/src/controllers.cpp
@@ -40,29 +40,33 @@ Controller::Controller()
   btns_[JoyButton::RIGHT_STICK_PUSH] = 10;
 }
 
+Controller::~Controller()
+{
+}
+
 void Controller::set_controller_input(const sensor_msgs::Joy& joy_msg)
 {
   input_msg_ = joy_msg;
 }
 
-float Controller::get_accelerator_value()
+float Controller::accelerator_value()
 {
   // The triggers report 1.0 when untouched, and change negatively all the way to -1.0 when fully pressed
   return -(input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]] - 1.0) / 2;
 }
 
-float Controller::get_brake_value()
+float Controller::brake_value()
 {
   // The triggers report 1.0 when untouched, and change negatively all the way to -1.0 when fully pressed
   return -(input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] - 1.0) / 2.0;
 }
 
-float Controller::get_steering_value(JoyAxis steering_axis)
+float Controller::steering_value(JoyAxis steering_axis)
 {
   return input_msg_.axes[axes_[steering_axis]];
 }
 
-int Controller::get_turn_signal_cmd()
+int Controller::turn_signal_cmd()
 {
   // Left on directional pad
   if (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] == AXES_MAX)
@@ -85,7 +89,7 @@ int Controller::get_turn_signal_cmd()
   }
 }
 
-int Controller::get_shift_cmd()
+int Controller::shift_cmd()
 {
   uint8_t desired_gear = 0x0;
   desired_gear |=
@@ -110,43 +114,29 @@ int Controller::get_shift_cmd()
   }
 }
 
-bool Controller::get_horn_cmd()
+bool Controller::horn_cmd()
 {
-  if (input_msg_.buttons[btns_[JoyButton::RIGHT_BUMPER]] == BUTTON_DOWN)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return (input_msg_.buttons[btns_[JoyButton::RIGHT_BUMPER]] == BUTTON_DOWN);
 }
 
-bool Controller::get_headlight_change()
+bool Controller::headlight_change()
 {
   // Up on directional pad
   return (input_msg_.axes[axes_[JoyAxis::DPAD_UD]] == AXES_MAX);
 }
 
-bool Controller::get_wiper_change()
+bool Controller::wiper_change()
 {
-  if (input_msg_.buttons[btns_[JoyButton::LEFT_BUMPER]] == BUTTON_DOWN)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return (input_msg_.buttons[btns_[JoyButton::LEFT_BUMPER]] == BUTTON_DOWN);
 }
 
-bool Controller::get_enable()
+bool Controller::enable()
 {
   return (input_msg_.buttons[btns_[JoyButton::START_PLUS]] == BUTTON_DOWN &&
           input_msg_.buttons[btns_[JoyButton::BACK_SELECT_MINUS]] == BUTTON_DOWN);
 }
 
-bool Controller::get_disable()
+bool Controller::disable()
 {
   return (input_msg_.buttons[btns_[JoyButton::BACK_SELECT_MINUS]] == BUTTON_DOWN &&
           input_msg_.buttons[btns_[JoyButton::START_PLUS]] != BUTTON_DOWN);
@@ -177,13 +167,13 @@ LogitechG29Controller::LogitechG29Controller()
   btns_[JoyButton::START_PLUS] = 10;
 }
 
-float LogitechG29Controller::get_accelerator_value()
+float LogitechG29Controller::accelerator_value()
 {
   // The pedals report -1.0 when untouched, and change positively to 1.0 when full pressed
   return (input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]] + 1.0) / 2.0;
 }
 
-float LogitechG29Controller::get_brake_value()
+float LogitechG29Controller::brake_value()
 {
   // The pedals report -1.0 when untouched, and change positively to 1.0 when full pressed
   return (input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] + 1.0) / 2.0;
@@ -213,7 +203,7 @@ HriSafeController::HriSafeController()
   // HRI Safe Remote has no bumper buttons!
 }
 
-float HriSafeController::get_accelerator_value()
+float HriSafeController::accelerator_value()
 {
   // Only consider center-to-up range as accelerator value
   if (input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]] <= 0.0)
@@ -223,7 +213,7 @@ float HriSafeController::get_accelerator_value()
   return 0.0;
 }
 
-float HriSafeController::get_brake_value()
+float HriSafeController::brake_value()
 {
   // Only consider center-to-up range as brake value
   if (input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] <= 0.0)
@@ -233,7 +223,7 @@ float HriSafeController::get_brake_value()
   return 0.0;
 }
 
-int HriSafeController::get_turn_signal_cmd()
+int HriSafeController::turn_signal_cmd()
 {
   if (input_msg_.axes[axes_[JoyAxis::RIGHT_STICK_UD]] < -0.5)
   {
@@ -253,24 +243,24 @@ int HriSafeController::get_turn_signal_cmd()
   }
 }
 
-bool HriSafeController::get_horn_cmd()
+bool HriSafeController::horn_cmd()
 {
   // Currently no button assigned to horn commands
   return false;
 }
 
-bool HriSafeController::get_wiper_change()
+bool HriSafeController::wiper_change()
 {
   // Currently no button assigned to wiper commands
   return false;
 }
 
-bool HriSafeController::get_enable()
+bool HriSafeController::enable()
 {
   return (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] <= -0.9);
 }
 
-bool HriSafeController::get_disable()
+bool HriSafeController::disable()
 {
   return (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] >= 0.9);
 }

--- a/src/controllers.cpp
+++ b/src/controllers.cpp
@@ -1,0 +1,275 @@
+/*
+ * Unpublished Copyright (c) 2009-2021 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the PACMod ROS 1.0 driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
+
+#include "pacmod_game_control/controllers.h"
+
+#include <pacmod_msgs/SystemCmdInt.h>
+
+// --- Generic gamepad controller (Logitech F310, XBOX)
+Controller::Controller()
+{
+  axes_[JoyAxis::LEFT_STICK_LR] = 0;
+  axes_[JoyAxis::LEFT_STICK_UD] = 1;
+
+  axes_[JoyAxis::RIGHT_STICK_LR] = 3;
+  axes_[JoyAxis::RIGHT_STICK_UD] = 4;
+
+  axes_[JoyAxis::LEFT_TRIGGER_AXIS] = 2;
+  axes_[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
+
+  axes_[JoyAxis::DPAD_LR] = 6;
+  axes_[JoyAxis::DPAD_UD] = 7;
+
+  btns_[JoyButton::BOTTOM_BTN] = 0;
+  btns_[JoyButton::RIGHT_BTN] = 1;
+  btns_[JoyButton::LEFT_BTN] = 2;
+  btns_[JoyButton::TOP_BTN] = 3;
+
+  btns_[JoyButton::LEFT_BUMPER] = 4;
+  btns_[JoyButton::RIGHT_BUMPER] = 5;
+
+  btns_[JoyButton::BACK_SELECT_MINUS] = 6;
+  btns_[JoyButton::START_PLUS] = 7;
+
+  // Currently unused
+  btns_[JoyButton::LEFT_STICK_PUSH] = 9;
+  btns_[JoyButton::RIGHT_STICK_PUSH] = 10;
+}
+
+void Controller::set_controller_input(const sensor_msgs::Joy& joy_msg)
+{
+  input_msg_ = joy_msg;
+}
+
+float Controller::get_accelerator_value()
+{
+  // The triggers report 1.0 when untouched, and change negatively all the way to -1.0 when fully pressed
+  return -(input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]] - 1.0) / 2;
+}
+
+float Controller::get_brake_value()
+{
+  // The triggers report 1.0 when untouched, and change negatively all the way to -1.0 when fully pressed
+  return -(input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] - 1.0) / 2.0;
+}
+
+int Controller::get_turn_signal_cmd()
+{
+  // Left on directional pad
+  if (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] == AXES_MAX)
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_LEFT;
+  }
+  // Right on directional pad
+  else if (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] == AXES_MIN)
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_RIGHT;
+  }
+  // Down on directional pad
+  else if (input_msg_.axes[axes_[JoyAxis::DPAD_UD]] == AXES_MIN)
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_HAZARDS;
+  }
+  else
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_NONE;
+  }
+}
+
+int Controller::get_shift_cmd()
+{
+  uint8_t desired_gear = 0x0;
+  desired_gear |=
+      (input_msg_.buttons[btns_[JoyButton::RIGHT_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_REVERSE |
+      (input_msg_.buttons[btns_[JoyButton::BOTTOM_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_HIGH |
+      (input_msg_.buttons[btns_[JoyButton::TOP_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_PARK |
+      (input_msg_.buttons[btns_[JoyButton::LEFT_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_NEUTRAL;
+
+  switch (desired_gear)
+  {
+    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_REVERSE:
+      return pacmod_msgs::SystemCmdInt::SHIFT_REVERSE;
+    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_HIGH:
+      return pacmod_msgs::SystemCmdInt::SHIFT_HIGH;
+    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_PARK:
+      return pacmod_msgs::SystemCmdInt::SHIFT_PARK;
+    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_NEUTRAL:
+      return pacmod_msgs::SystemCmdInt::SHIFT_NEUTRAL;
+    // If we've got an invalid command (or multiple buttons pressed) return invalid
+    default:
+      return -1;
+  }
+}
+
+bool Controller::get_horn_cmd()
+{
+  if (input_msg_.buttons[btns_[JoyButton::RIGHT_BUMPER]] == BUTTON_DOWN)
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+bool Controller::get_headlight_change()
+{
+  // Up on directional pad
+  return (input_msg_.axes[axes_[JoyAxis::DPAD_UD]] == AXES_MAX);
+}
+
+bool Controller::get_wiper_change()
+{
+  if (input_msg_.buttons[btns_[JoyButton::LEFT_BUMPER]] == BUTTON_DOWN)
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+bool Controller::get_enable()
+{
+  return (input_msg_.buttons[btns_[JoyButton::START_PLUS]] == BUTTON_DOWN &&
+          input_msg_.buttons[btns_[JoyButton::BACK_SELECT_MINUS]] == BUTTON_DOWN);
+}
+
+bool Controller::get_disable()
+{
+  return (input_msg_.buttons[btns_[JoyButton::BACK_SELECT_MINUS]] == BUTTON_DOWN &&
+          input_msg_.buttons[btns_[JoyButton::START_PLUS]] != BUTTON_DOWN);
+}
+
+
+// --- Logitech G29, racing wheel with pedals
+LogitechG29Controller::LogitechG29Controller()
+{
+  // Set to match the G29 controller_type's max center-to-lock steering angle (radians)
+  // max_rot_rad = 7.85;
+  // steering wheel, not right stick
+  axes_[JoyAxis::RIGHT_STICK_LR] = 0;
+  // throttle pedal, not right trigger
+  axes_[JoyAxis::RIGHT_TRIGGER_AXIS] = 2;
+  // brake pedal, not left trigger
+  axes_[JoyAxis::LEFT_TRIGGER_AXIS] = 3;
+  axes_[JoyAxis::DPAD_LR] = 4;
+  axes_[JoyAxis::DPAD_UD] = 5;
+
+  btns_[JoyButton::BOTTOM_BTN] = 0;
+  btns_[JoyButton::RIGHT_BTN] = 2;
+  btns_[JoyButton::LEFT_BTN] = 1;
+  btns_[JoyButton::TOP_BTN] = 3;
+
+  // Following two are two blue buttons on the left
+  btns_[JoyButton::LEFT_BUMPER] = 7;
+  btns_[JoyButton::BACK_SELECT_MINUS] = 11;
+  // Following two are two blue buttons on the right
+  btns_[JoyButton::RIGHT_BUMPER] = 6;
+  btns_[JoyButton::START_PLUS] = 10;
+}
+
+float LogitechG29Controller::get_accelerator_value()
+{
+  // The pedals report -1.0 when untouched, and change positively to 1.0 when full pressed
+  return (input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]] + 1.0) / 2.0;
+}
+
+float LogitechG29Controller::get_brake_value()
+{
+  // The pedals report -1.0 when untouched, and change positively to 1.0 when full pressed
+  return (input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] + 1.0) / 2.0;
+}
+
+
+// --- HRI Safe Remote Controller
+HriSafeController::HriSafeController()
+{
+  axes_[JoyAxis::LEFT_STICK_LR] = 0;
+  axes_[JoyAxis::LEFT_STICK_UD] = 1;
+
+  axes_[JoyAxis::RIGHT_STICK_LR] = 3;
+  axes_[JoyAxis::RIGHT_STICK_UD] = 4;
+
+  axes_[JoyAxis::LEFT_TRIGGER_AXIS] = 2;
+  axes_[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
+
+  axes_[JoyAxis::DPAD_LR] = 6;
+  axes_[JoyAxis::DPAD_UD] = 7;
+
+  // TODO(jwhitleyastuff): Complete missing buttons
+  btns_[JoyButton::BOTTOM_BTN] = 0;
+  btns_[JoyButton::RIGHT_BTN] = 1;
+  btns_[JoyButton::TOP_BTN] = 2;
+  btns_[JoyButton::LEFT_BTN] = 3;
+
+  // HRI Safe Remote has no bumper buttons!
+}
+
+float HriSafeController::get_accelerator_value()
+{
+  // Only consider center-to-up range as accelerator value
+  if (input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]] <= 0.0)
+  {
+    return  -(input_msg_.axes[axes_[JoyAxis::RIGHT_TRIGGER_AXIS]]);
+  }
+  return 0.0;
+}
+
+float HriSafeController::get_brake_value()
+{
+  // Only consider center-to-up range as brake value
+  if (input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] <= 0.0)
+  {
+    return -(input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]]);
+  }
+  return 0.0;
+}
+
+int HriSafeController::get_turn_signal_cmd()
+{
+  if (input_msg_.axes[axes_[JoyAxis::RIGHT_STICK_UD]] < -0.5)
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_HAZARDS;
+  }
+  else if (input_msg_.axes[axes_[JoyAxis::RIGHT_STICK_LR]] > 0.5)
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_LEFT;
+  }
+  else if (input_msg_.axes[axes_[JoyAxis::RIGHT_STICK_LR]] < -0.5)
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_RIGHT;
+  }
+  else
+  {
+    return pacmod_msgs::SystemCmdInt::TURN_NONE;
+  }
+}
+
+bool HriSafeController::get_horn_cmd()
+{
+  // Currently no button assigned to horn commands
+  return false;
+}
+
+bool HriSafeController::get_wiper_change()
+{
+  // Currently no button assigned to wiper commands
+  return false;
+}
+
+bool HriSafeController::get_enable()
+{
+  return (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] <= -0.9);
+}
+
+bool HriSafeController::get_disable()
+{
+  return (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] >= 0.9);
+}

--- a/src/controllers.cpp
+++ b/src/controllers.cpp
@@ -57,6 +57,11 @@ float Controller::get_brake_value()
   return -(input_msg_.axes[axes_[JoyAxis::LEFT_TRIGGER_AXIS]] - 1.0) / 2.0;
 }
 
+float Controller::get_steering_value(JoyAxis steering_axis)
+{
+  return input_msg_.axes[axes_[steering_axis]];
+}
+
 int Controller::get_turn_signal_cmd()
 {
   // Left on directional pad
@@ -151,8 +156,6 @@ bool Controller::get_disable()
 // --- Logitech G29, racing wheel with pedals
 LogitechG29Controller::LogitechG29Controller()
 {
-  // Set to match the G29 controller_type's max center-to-lock steering angle (radians)
-  // max_rot_rad = 7.85;
   // steering wheel, not right stick
   axes_[JoyAxis::RIGHT_STICK_LR] = 0;
   // throttle pedal, not right trigger

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -125,7 +125,8 @@ void PublishControl::publish_steering_message(const sensor_msgs::Joy::ConstPtr& 
       vehicle_type == VehicleType::JUPITER_SPIRIT)
     range_scale = 1.0;
   else
-    range_scale = fabs(controller->get_steering_value(steering_axis)) * (STEER_OFFSET - ROT_RANGE_SCALER_LB) + ROT_RANGE_SCALER_LB;
+    range_scale = fabs(controller->get_steering_value(steering_axis)) * (STEER_OFFSET - ROT_RANGE_SCALER_LB) +
+                  ROT_RANGE_SCALER_LB;
 
   // Decreases the angular rotation rate of the steering wheel when moving faster
   float speed_based_damping = 1.0;
@@ -179,7 +180,8 @@ void PublishControl::publish_turn_signal_message()
       turn_signal_cmd = turn_signal_rpt;
   }
 
-  // Only publish if we are requesting a different turn signal than is currently active, or we just engaged and need to clear override
+  // Only publish if we are requesting a different turn signal than is currently active, or we just engaged and need to
+  // clear override
   if (turn_signal_cmd != turn_signal_rpt || local_enable != prev_enable)
   {
     turn_signal_cmd_pub_msg.command = turn_signal_cmd;

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -49,11 +49,11 @@ void PublishControl::callback_control(const sensor_msgs::Joy::ConstPtr& msg)
 
     if (local_enable == true || local_enable != prev_enable)
     {
-      publish_steering_message(msg);
+      publish_steering_message();
       publish_turn_signal_message();
       publish_shifting_message();
-      publish_accelerator_message(msg);
-      publish_brake_message(msg);
+      publish_accelerator_message();
+      publish_brake_message();
       publish_lights_horn_wipers_message();
     }
 
@@ -105,7 +105,7 @@ void PublishControl::callback_rear_pass_door_rpt(const pacmod_msgs::SystemRptInt
 }
 
 // Publishing
-void PublishControl::publish_steering_message(const sensor_msgs::Joy::ConstPtr& msg)
+void PublishControl::publish_steering_message()
 {
   pacmod_msgs::SteerSystemCmd steer_msg;
 
@@ -233,7 +233,7 @@ void PublishControl::publish_shifting_message()
   }
 }
 
-void PublishControl::publish_accelerator_message(const sensor_msgs::Joy::ConstPtr& msg)
+void PublishControl::publish_accelerator_message()
 {
   pacmod_msgs::SystemCmdFloat accelerator_cmd_pub_msg;
 
@@ -263,7 +263,7 @@ void PublishControl::publish_accelerator_message(const sensor_msgs::Joy::ConstPt
   accelerator_cmd_pub.publish(accelerator_cmd_pub_msg);
 }
 
-void PublishControl::publish_brake_message(const sensor_msgs::Joy::ConstPtr& msg)
+void PublishControl::publish_brake_message()
 {
   pacmod_msgs::SystemCmdFloat brake_msg;
 

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -125,7 +125,7 @@ void PublishControl::publish_steering_message(const sensor_msgs::Joy::ConstPtr& 
       vehicle_type == VehicleType::JUPITER_SPIRIT)
     range_scale = 1.0;
   else
-    range_scale = fabs(msg->axes[axes[steering_axis]]) * (STEER_OFFSET - ROT_RANGE_SCALER_LB) + ROT_RANGE_SCALER_LB;
+    range_scale = fabs(controller->get_steering_value(steering_axis)) * (STEER_OFFSET - ROT_RANGE_SCALER_LB) + ROT_RANGE_SCALER_LB;
 
   // Decreases the angular rotation rate of the steering wheel when moving faster
   float speed_based_damping = 1.0;
@@ -149,7 +149,7 @@ void PublishControl::publish_steering_message(const sensor_msgs::Joy::ConstPtr& 
     else
       speed_based_damping = 0.33333;  // clips the equation assuming 1 offset and 1.5 scale_factor
 
-  steer_msg.command = (range_scale * max_rot_rad) * msg->axes[axes[steering_axis]];
+  steer_msg.command = (range_scale * max_rot_rad) * controller->get_steering_value(steering_axis);
   steer_msg.rotation_rate = steering_max_speed * speed_based_damping;
   steering_set_position_with_speed_limit_pub.publish(steer_msg);
 }

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -107,8 +107,6 @@ void PublishControl::callback_rear_pass_door_rpt(const pacmod_msgs::SystemRptInt
 // Publishing
 void PublishControl::publish_steering_message(const sensor_msgs::Joy::ConstPtr& msg)
 {
-  // Steering
-  // Axis 0 is left thumbstick, axis 3 is right. Speed in rad/sec.
   pacmod_msgs::SteerSystemCmd steer_msg;
 
   steer_msg.enable = local_enable;

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -125,8 +125,8 @@ void PublishControl::publish_steering_message()
       vehicle_type == VehicleType::JUPITER_SPIRIT)
     range_scale = 1.0;
   else
-    range_scale = fabs(controller->get_steering_value(steering_axis)) * (STEER_OFFSET - ROT_RANGE_SCALER_LB) +
-                  ROT_RANGE_SCALER_LB;
+    range_scale =
+        fabs(controller->steering_value(steering_axis)) * (STEER_OFFSET - ROT_RANGE_SCALER_LB) + ROT_RANGE_SCALER_LB;
 
   // Decreases the angular rotation rate of the steering wheel when moving faster
   float speed_based_damping = 1.0;
@@ -150,7 +150,7 @@ void PublishControl::publish_steering_message()
     else
       speed_based_damping = 0.33333;  // clips the equation assuming 1 offset and 1.5 scale_factor
 
-  steer_msg.command = (range_scale * max_rot_rad) * controller->get_steering_value(steering_axis);
+  steer_msg.command = (range_scale * max_rot_rad) * controller->steering_value(steering_axis);
   steer_msg.rotation_rate = steering_max_speed * speed_based_damping;
   steering_set_position_with_speed_limit_pub.publish(steer_msg);
 }
@@ -169,7 +169,7 @@ void PublishControl::publish_turn_signal_message()
     turn_signal_cmd_pub_msg.clear_faults = true;
   }
 
-  int turn_signal_cmd = controller->get_turn_signal_cmd();
+  int turn_signal_cmd = controller->turn_signal_cmd();
 
   if (local_enable != prev_enable)
   {
@@ -205,7 +205,7 @@ void PublishControl::publish_shifting_message()
       shift_cmd_pub_msg.clear_faults = true;
     }
 
-    int shift_cmd = controller->get_shift_cmd();
+    int shift_cmd = controller->shift_cmd();
 
     // Skip if invalid (multiple buttons pressed)
     if (shift_cmd == -1)
@@ -252,12 +252,12 @@ void PublishControl::publish_accelerator_message()
       vehicle_type == VehicleType::VEHICLE_4 || vehicle_type == VehicleType::VEHICLE_5 ||
       vehicle_type == VehicleType::VEHICLE_6)
   {
-    accelerator_cmd_pub_msg.command = accel_scale_val * controller->get_accelerator_value();
+    accelerator_cmd_pub_msg.command = accel_scale_val * controller->accelerator_value();
   }
   else
   {
     accelerator_cmd_pub_msg.command =
-        accel_scale_val * controller->get_accelerator_value() * ACCEL_SCALE_FACTOR + ACCEL_OFFSET;
+        accel_scale_val * controller->accelerator_value() * ACCEL_SCALE_FACTOR + ACCEL_OFFSET;
   }
 
   accelerator_cmd_pub.publish(accelerator_cmd_pub_msg);
@@ -277,7 +277,7 @@ void PublishControl::publish_brake_message()
     brake_msg.clear_faults = true;
   }
 
-  float brake_value = brake_scale_val * controller->get_brake_value();
+  float brake_value = brake_scale_val * controller->brake_value();
   if (vehicle_type == VehicleType::LEXUS_RX_450H)
   {
     // These constants came from playing around in excel until stuff looked good. Seems to work okay
@@ -305,7 +305,7 @@ void PublishControl::publish_lights_horn_wipers_message()
     headlight_cmd_pub_msg.ignore_overrides = false;
 
     // Headlights
-    if (controller->get_headlight_change())
+    if (controller->headlight_change())
     {
       // TODO(icolwell-as): What is special about vehicle 5?
       if (vehicle_type == VehicleType::VEHICLE_5)
@@ -356,7 +356,7 @@ void PublishControl::publish_lights_horn_wipers_message()
       horn_cmd_pub_msg.clear_faults = true;
     }
 
-    horn_cmd_pub_msg.command = controller->get_horn_cmd();
+    horn_cmd_pub_msg.command = controller->horn_cmd();
     horn_cmd_pub.publish(horn_cmd_pub_msg);
   }
 
@@ -367,7 +367,7 @@ void PublishControl::publish_lights_horn_wipers_message()
     wiper_cmd_pub_msg.ignore_overrides = false;
 
     // Windshield wipers
-    if (controller->get_wiper_change())
+    if (controller->wiper_change())
     {
       // Rotate through wiper states as button is pressed
       PublishControl::wiper_state++;
@@ -399,7 +399,7 @@ void PublishControl::check_is_enabled()
   enable_mutex.unlock();
 
   // Enable
-  if (controller->get_enable() && !local_enable)
+  if (controller->enable() && !local_enable)
   {
     std_msgs::Bool bool_pub_msg;
     bool_pub_msg.data = true;
@@ -410,7 +410,7 @@ void PublishControl::check_is_enabled()
   }
 
   // Disable
-  if (controller->get_disable() && local_enable)
+  if (controller->disable() && local_enable)
   {
     std_msgs::Bool bool_pub_msg;
     bool_pub_msg.data = false;

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -173,7 +173,7 @@ void PublishControl::publish_turn_signal_message()
 
   if (local_enable != prev_enable)
   {
-    // TODO: What is special about vehicle 6?
+    // TODO(icolwell-as): What is special about vehicle 6?
     if (vehicle_type == VehicleType::VEHICLE_6)
       turn_signal_cmd = pacmod_msgs::SystemCmdInt::TURN_NONE;
     else
@@ -307,7 +307,7 @@ void PublishControl::publish_lights_horn_wipers_message()
     // Headlights
     if (controller->get_headlight_change())
     {
-      // TODO: What is special about vehicle 5?
+      // TODO(icolwell-as): What is special about vehicle 5?
       if (vehicle_type == VehicleType::VEHICLE_5)
       {
         if (headlight_state == 1)

--- a/src/startup_checks.cpp
+++ b/src/startup_checks.cpp
@@ -140,17 +140,6 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
       axes[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
       axes[JoyAxis::DPAD_LR] = 6;
       axes[JoyAxis::DPAD_UD] = 7;
-
-      btns[JoyButton::BOTTOM_BTN] = 0;
-      btns[JoyButton::RIGHT_BTN] = 1;
-      btns[JoyButton::LEFT_BTN] = 2;
-      btns[JoyButton::TOP_BTN] = 3;
-      btns[JoyButton::LEFT_BUMPER] = 4;
-      btns[JoyButton::RIGHT_BUMPER] = 5;
-      btns[JoyButton::BACK_SELECT_MINUS] = 6;
-      btns[JoyButton::START_PLUS] = 7;
-      btns[JoyButton::LEFT_STICK_PUSH] = 9;
-      btns[JoyButton::RIGHT_STICK_PUSH] = 10;
     }
     else if (controller_string == "HRI_SAFE_REMOTE")
     {
@@ -165,12 +154,6 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
       axes[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
       axes[JoyAxis::DPAD_LR] = 6;
       axes[JoyAxis::DPAD_UD] = 7;
-
-      // TODO(jwhitleyastuff): Complete missing buttons
-      btns[JoyButton::BOTTOM_BTN] = 0;
-      btns[JoyButton::RIGHT_BTN] = 1;
-      btns[JoyButton::TOP_BTN] = 2;
-      btns[JoyButton::LEFT_BTN] = 3;
     }
     else if (controller_string == "LOGITECH_G29")
     {
@@ -187,18 +170,6 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
       axes[JoyAxis::LEFT_TRIGGER_AXIS] = 3;
       axes[JoyAxis::DPAD_LR] = 4;
       axes[JoyAxis::DPAD_UD] = 5;
-
-      btns[JoyButton::BOTTOM_BTN] = 0;
-      btns[JoyButton::RIGHT_BTN] = 2;
-      btns[JoyButton::LEFT_BTN] = 1;
-      btns[JoyButton::TOP_BTN] = 3;
-
-      // Following two are two blue buttons on the left
-      btns[JoyButton::LEFT_BUMPER] = 7;
-      btns[JoyButton::BACK_SELECT_MINUS] = 11;
-      // Following two are two blue buttons on the right
-      btns[JoyButton::RIGHT_BUMPER] = 6;
-      btns[JoyButton::START_PLUS] = 10;
     }
     else
     {

--- a/src/startup_checks.cpp
+++ b/src/startup_checks.cpp
@@ -130,17 +130,17 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
     if (controller_string == "LOGITECH_F310" || controller_string == "XBOX_ONE")
     {
       controller_type = (controller_string == "LOGITECH_F310") ? GamepadType::LOGITECH_F310 : GamepadType::XBOX_ONE;
-      controller = new Controller();
+      controller = std::make_unique<Controller>();
     }
     else if (controller_string == "HRI_SAFE_REMOTE")
     {
       controller_type = GamepadType::HRI_SAFE_REMOTE;
-      controller = new HriSafeController();
+      controller = std::make_unique<HriSafeController>();
     }
     else if (controller_string == "LOGITECH_G29")
     {
       controller_type = GamepadType::LOGITECH_G29;
-      controller = new LogitechG29Controller();
+      controller = std::make_unique<LogitechG29Controller>();
 
       // Set to match the G29 controller_type's max center-to-lock steering angle (radians).
       max_rot_rad = 7.85;

--- a/src/startup_checks.cpp
+++ b/src/startup_checks.cpp
@@ -129,7 +129,8 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
 
     if (controller_string == "LOGITECH_F310" || controller_string == "XBOX_ONE")
     {
-      controller = (controller_string == "LOGITECH_F310") ? GamepadType::LOGITECH_F310 : GamepadType::XBOX_ONE;
+      controller_type = (controller_string == "LOGITECH_F310") ? GamepadType::LOGITECH_F310 : GamepadType::XBOX_ONE;
+      controller = new Controller();
 
       axes[JoyAxis::LEFT_STICK_LR] = 0;
       axes[JoyAxis::LEFT_STICK_UD] = 1;
@@ -153,15 +154,19 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
     }
     else if (controller_string == "HRI_SAFE_REMOTE")
     {
-      controller = GamepadType::HRI_SAFE_REMOTE;
+      controller_type = GamepadType::HRI_SAFE_REMOTE;
+      controller = new HriSafeController();
 
-      // TODO(jwhitleyastuff): Complete missing buttons
       axes[JoyAxis::LEFT_STICK_LR] = 0;
+      axes[JoyAxis::LEFT_STICK_UD] = 1;
+      axes[JoyAxis::LEFT_TRIGGER_AXIS] = 2;
       axes[JoyAxis::RIGHT_STICK_LR] = 3;
       axes[JoyAxis::RIGHT_STICK_UD] = 4;
+      axes[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
       axes[JoyAxis::DPAD_LR] = 6;
       axes[JoyAxis::DPAD_UD] = 7;
 
+      // TODO(jwhitleyastuff): Complete missing buttons
       btns[JoyButton::BOTTOM_BTN] = 0;
       btns[JoyButton::RIGHT_BTN] = 1;
       btns[JoyButton::TOP_BTN] = 2;
@@ -169,9 +174,10 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
     }
     else if (controller_string == "LOGITECH_G29")
     {
-      controller = GamepadType::LOGITECH_G29;
+      controller_type = GamepadType::LOGITECH_G29;
+      controller = new LogitechG29Controller();
 
-      // Set to match the G29 controller's max center-to-lock steering angle (radians).
+      // Set to match the G29 controller_type's max center-to-lock steering angle (radians).
       max_rot_rad = 7.85;
       // steering wheel, not right stick
       axes[JoyAxis::RIGHT_STICK_LR] = 0;
@@ -193,30 +199,6 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
       // Following two are two blue buttons on the right
       btns[JoyButton::RIGHT_BUMPER] = 6;
       btns[JoyButton::START_PLUS] = 10;
-    }
-    else if (controller_string == "NINTENDO_SWITCH_WIRED_PLUS")
-    {
-      controller = GamepadType::NINTENDO_SWITCH_WIRED_PLUS;
-
-      axes[JoyAxis::LEFT_STICK_LR] = 0;
-      axes[JoyAxis::LEFT_STICK_UD] = 1;
-      axes[JoyAxis::RIGHT_STICK_LR] = 2;
-      axes[JoyAxis::RIGHT_STICK_UD] = 3;
-      axes[JoyAxis::DPAD_LR] = 4;
-      axes[JoyAxis::DPAD_UD] = 5;
-
-      btns[JoyButton::LEFT_BTN] = 0;
-      btns[JoyButton::BOTTOM_BTN] = 1;
-      btns[JoyButton::RIGHT_BTN] = 2;
-      btns[JoyButton::TOP_BTN] = 3;
-      btns[JoyButton::LEFT_BUMPER] = 4;
-      btns[JoyButton::RIGHT_BUMPER] = 5;
-      btns[JoyButton::LEFT_TRIGGER_BTN] = 6;
-      btns[JoyButton::RIGHT_TRIGGER_BTN] = 7;
-      btns[JoyButton::BACK_SELECT_MINUS] = 8;
-      btns[JoyButton::START_PLUS] = 9;
-      btns[JoyButton::LEFT_STICK_PUSH] = 10;
-      btns[JoyButton::RIGHT_STICK_PUSH] = 11;
     }
     else
     {

--- a/src/startup_checks.cpp
+++ b/src/startup_checks.cpp
@@ -131,29 +131,11 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
     {
       controller_type = (controller_string == "LOGITECH_F310") ? GamepadType::LOGITECH_F310 : GamepadType::XBOX_ONE;
       controller = new Controller();
-
-      axes[JoyAxis::LEFT_STICK_LR] = 0;
-      axes[JoyAxis::LEFT_STICK_UD] = 1;
-      axes[JoyAxis::LEFT_TRIGGER_AXIS] = 2;
-      axes[JoyAxis::RIGHT_STICK_LR] = 3;
-      axes[JoyAxis::RIGHT_STICK_UD] = 4;
-      axes[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
-      axes[JoyAxis::DPAD_LR] = 6;
-      axes[JoyAxis::DPAD_UD] = 7;
     }
     else if (controller_string == "HRI_SAFE_REMOTE")
     {
       controller_type = GamepadType::HRI_SAFE_REMOTE;
       controller = new HriSafeController();
-
-      axes[JoyAxis::LEFT_STICK_LR] = 0;
-      axes[JoyAxis::LEFT_STICK_UD] = 1;
-      axes[JoyAxis::LEFT_TRIGGER_AXIS] = 2;
-      axes[JoyAxis::RIGHT_STICK_LR] = 3;
-      axes[JoyAxis::RIGHT_STICK_UD] = 4;
-      axes[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
-      axes[JoyAxis::DPAD_LR] = 6;
-      axes[JoyAxis::DPAD_UD] = 7;
     }
     else if (controller_string == "LOGITECH_G29")
     {
@@ -162,14 +144,6 @@ bool PublishControl::check_controller_type(const ros::NodeHandle& nodeH)
 
       // Set to match the G29 controller_type's max center-to-lock steering angle (radians).
       max_rot_rad = 7.85;
-      // steering wheel, not right stick
-      axes[JoyAxis::RIGHT_STICK_LR] = 0;
-      // throttle pedal, not right trigger
-      axes[JoyAxis::RIGHT_TRIGGER_AXIS] = 2;
-      // brake pedal, not left trigger
-      axes[JoyAxis::LEFT_TRIGGER_AXIS] = 3;
-      axes[JoyAxis::DPAD_LR] = 4;
-      axes[JoyAxis::DPAD_UD] = 5;
     }
     else
     {

--- a/src/startup_checks.cpp
+++ b/src/startup_checks.cpp
@@ -10,6 +10,7 @@
 
 #include "pacmod_game_control/publish_control.h"
 
+#include <memory>
 #include <string>
 
 bool PublishControl::run_startup_checks_error()


### PR DESCRIPTION
Resolves #86 with the following changes:

- Removes all controller-related code from `publish_control.cpp` and places it in a new `controllers.cpp` file. Doing so also removed a lot of code duplication from `publish_control.cpp`.
- Each supported controller that differs in some significant way can inherit from the base controller class and modify only what is different.
- Support for Nintendo switch pro controller has been removed for simplicity and maintenance reasons.
- The `publish_rear_pass_door_message` function has been removed since it only applies to a very specific command on a single vehicle. If it needs to be added back in the future, we can devise a new control scheme to accommodate these vehicle-specific "special" functions.
- Wiper controls have been moved to the left bumper to match the existing documentation.

Only tested with an xbox controller at the moment.