### PR TITLE
Remove some vehicle-specific code 

### DIFF
--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -20,6 +20,7 @@
 #include <pacmod_msgs/SystemCmdBool.h>
 #include <pacmod_msgs/SystemCmdFloat.h>
 #include <pacmod_msgs/SystemCmdInt.h>
+#include <pacmod_msgs/SystemRptBool.h>
 #include <pacmod_msgs/SystemRptInt.h>
 
 class PublishControl
@@ -33,6 +34,9 @@ public:
   void callback_shift_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
   void callback_turn_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
   void callback_rear_pass_door_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
+  void callback_lights_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
+  void callback_horn_rpt(const pacmod_msgs::SystemRptBool::ConstPtr& msg);
+  void callback_wiper_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
 
   // public variables
   JoyAxis steering_axis = JoyAxis::LEFT_STICK_LR;
@@ -62,7 +66,9 @@ private:
   void publish_shifting_message();
   void publish_accelerator_message();
   void publish_brake_message();
-  void publish_lights_horn_wipers_message();
+  void publish_lights();
+  void publish_horn();
+  void publish_wipers();
 
   // Startup checks
   bool run_startup_checks_error();
@@ -93,6 +99,9 @@ private:
   ros::Subscriber shift_sub;
   ros::Subscriber turn_sub;
   ros::Subscriber rear_pass_door_sub;
+  ros::Subscriber lights_sub;
+  ros::Subscriber horn_sub;
+  ros::Subscriber wiper_sub;
 
   // state vectors
   std::vector<float> last_axes;
@@ -103,6 +112,10 @@ private:
   bool local_enable;
   bool recent_state_change;
   uint8_t state_change_debounce_count;
+
+  bool lights_api_available = false;
+  bool horn_api_available = false;
+  bool wiper_api_available = false;
 
   // mutex
   std::mutex enable_mutex;

--- a/launch/pacmod_game_control.launch
+++ b/launch/pacmod_game_control.launch
@@ -31,10 +31,10 @@
   <!-- 4.71239 is fast but jerky. Speed in rad/sec.-->
   <arg name="steering_max_speed" default="3.3"/>
 
-  <!-- Scales raw joystick input -->
+  <!-- Scales accel commands, useful for decreasing sensitivity -->
   <arg name="accel_scale_val" default="1.0"/>
 
-  <!-- Scales raw joystick input -->
+  <!-- Scales brake commands, useful for decreasing sensitivity -->
   <arg name="brake_scale_val" default="1.0"/>
 
   <!-- For GEM, 11.176m/s -->


### PR DESCRIPTION
Resolves #92 by removing some vehicle-specific code in favor of dynamically detecting what features (horn, lights, wipers) the vehicle platform supports.

The GEM-related code will have to stay for now since the control scheme is quite different from other vehicles.