### PR TITLE
Update to pacmod3_msgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             apt-get update -qq
             source /opt/ros/*/setup.bash
             mkdir pacmod_game_control && mv `find -maxdepth 1 -not -name . -not -name pacmod_game_control` pacmod_game_control/
-            rosdep install --from-paths . --ignore-src -y
+            rosdep update && rosdep install --from-paths . --ignore-src -y
             cd ..
             catkin init
             catkin config --extend /opt/ros/$ROS_DISTRO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,14 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   sensor_msgs
-  pacmod_msgs
+  pacmod3_msgs
   joy
 )
 
 catkin_package(CATKIN_DEPENDS
   std_msgs
   sensor_msgs
-  pacmod_msgs
+  pacmod3_msgs
   joy
 )
 

--- a/include/pacmod_game_control/globals.h
+++ b/include/pacmod_game_control/globals.h
@@ -12,11 +12,6 @@
 #include <mutex>
 #include <unordered_map>
 
-#include <ros/ros.h>
-#include <sensor_msgs/Joy.h>
-#include <std_msgs/Bool.h>
-#include <pacmod_msgs/VehicleSpeedRpt.h>
-
 enum class GamepadType
 {
   LOGITECH_F310,

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -35,7 +35,6 @@ public:
   void callback_pacmod_enable(const std_msgs::Bool::ConstPtr& msg);
   void callback_shift_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
   void callback_turn_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
-  void callback_rear_pass_door_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
   void callback_lights_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
   void callback_horn_rpt(const pacmod3_msgs::SystemRptBool::ConstPtr& msg);
   void callback_wiper_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
@@ -57,7 +56,6 @@ public:
   int wiper_state = 0;
   int last_shift_cmd = 0;
   int turn_signal_rpt = pacmod3_msgs::SystemRptInt::TURN_NONE;
-  int last_rear_pass_door_cmd = 0;
   float last_brake_cmd = 0.0;
 
 private:
@@ -82,7 +80,6 @@ private:
 
   // ROS publishers
   ros::Publisher turn_signal_cmd_pub;
-  ros::Publisher rear_pass_door_cmd_pub;
   ros::Publisher headlight_cmd_pub;
   ros::Publisher horn_cmd_pub;
   ros::Publisher wiper_cmd_pub;
@@ -98,7 +95,6 @@ private:
   ros::Subscriber enable_sub;
   ros::Subscriber shift_sub;
   ros::Subscriber turn_sub;
-  ros::Subscriber rear_pass_door_sub;
   ros::Subscriber lights_sub;
   ros::Subscriber horn_sub;
   ros::Subscriber wiper_sub;

--- a/include/pacmod_game_control/publish_control.h
+++ b/include/pacmod_game_control/publish_control.h
@@ -16,12 +16,14 @@
 #include <vector>
 #include <unordered_map>
 
-#include <pacmod_msgs/SteerSystemCmd.h>
-#include <pacmod_msgs/SystemCmdBool.h>
-#include <pacmod_msgs/SystemCmdFloat.h>
-#include <pacmod_msgs/SystemCmdInt.h>
-#include <pacmod_msgs/SystemRptBool.h>
-#include <pacmod_msgs/SystemRptInt.h>
+#include <ros/ros.h>
+#include <pacmod3_msgs/SystemCmdBool.h>
+#include <pacmod3_msgs/SystemCmdFloat.h>
+#include <pacmod3_msgs/SystemCmdInt.h>
+#include <pacmod3_msgs/SystemRptBool.h>
+#include <pacmod3_msgs/SystemRptInt.h>
+#include <pacmod3_msgs/VehicleSpeedRpt.h>
+#include <std_msgs/Bool.h>
 
 class PublishControl
 {
@@ -29,14 +31,14 @@ public:
   // public functions
   void init();
   void callback_control(const sensor_msgs::Joy::ConstPtr& msg);
-  void callback_veh_speed(const pacmod_msgs::VehicleSpeedRpt::ConstPtr& msg);
+  void callback_veh_speed(const pacmod3_msgs::VehicleSpeedRpt::ConstPtr& msg);
   void callback_pacmod_enable(const std_msgs::Bool::ConstPtr& msg);
-  void callback_shift_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
-  void callback_turn_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
-  void callback_rear_pass_door_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
-  void callback_lights_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
-  void callback_horn_rpt(const pacmod_msgs::SystemRptBool::ConstPtr& msg);
-  void callback_wiper_rpt(const pacmod_msgs::SystemRptInt::ConstPtr& msg);
+  void callback_shift_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
+  void callback_turn_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
+  void callback_rear_pass_door_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
+  void callback_lights_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
+  void callback_horn_rpt(const pacmod3_msgs::SystemRptBool::ConstPtr& msg);
+  void callback_wiper_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
 
   // public variables
   float max_rot_rad = MAX_ROT_RAD_DEFAULT;
@@ -46,7 +48,7 @@ public:
   float accel_scale_val = 1.0;
   float brake_scale_val = 1.0;
   float steering_max_speed = std::numeric_limits<float>::quiet_NaN();
-  pacmod_msgs::VehicleSpeedRpt::ConstPtr last_speed_rpt = NULL;
+  pacmod3_msgs::VehicleSpeedRpt::ConstPtr last_speed_rpt = NULL;
   bool pacmod_enable = false;
   bool prev_enable = false;
   bool last_pacmod_state = false;
@@ -54,7 +56,7 @@ public:
   bool headlight_state_change = false;
   int wiper_state = 0;
   int last_shift_cmd = 0;
-  int turn_signal_rpt = pacmod_msgs::SystemRptInt::TURN_NONE;
+  int turn_signal_rpt = pacmod3_msgs::SystemRptInt::TURN_NONE;
   int last_rear_pass_door_cmd = 0;
   float last_brake_cmd = 0.0;
 

--- a/launch/pacmod_game_control.launch
+++ b/launch/pacmod_game_control.launch
@@ -49,20 +49,18 @@
   </include>
 
   <!-- Game Control -->
-  <group ns="game_control">
-    <node pkg="joy" type="joy_node" name="joy">
-      <param name="coalesce_interval" type="double" value="0.02"/>
-      <param name="default_trig_val" value="true"/>
-      <param name="deadzone" value="0.0"/>
-    </node>
+  <node pkg="joy" type="joy_node" name="joy">
+    <param name="coalesce_interval" type="double" value="0.02"/>
+    <param name="default_trig_val" value="true"/>
+    <param name="deadzone" value="0.0"/>
+  </node>
 
-    <node pkg="pacmod_game_control" type="pacmod_game_control_node" name="pacmod_game_control" output="screen">
-      <param name="pacmod_vehicle_type" value="$(arg pacmod_vehicle_type)"/>
-      <param name="controller_type" value="$(arg controller_type)"/>
-      <param name="steering_max_speed" value="$(arg steering_max_speed)"/>
-      <param name="accel_scale_val" value="$(arg accel_scale_val)"/>
-      <param name="brake_scale_val" value="$(arg brake_scale_val)"/>
-      <param name="max_veh_speed" value="$(arg max_veh_speed)" />
-    </node>
-  </group>
+  <node pkg="pacmod_game_control" type="pacmod_game_control_node" name="pacmod_game_control" output="screen">
+    <param name="pacmod_vehicle_type" value="$(arg pacmod_vehicle_type)"/>
+    <param name="controller_type" value="$(arg controller_type)"/>
+    <param name="steering_max_speed" value="$(arg steering_max_speed)"/>
+    <param name="accel_scale_val" value="$(arg accel_scale_val)"/>
+    <param name="brake_scale_val" value="$(arg brake_scale_val)"/>
+    <param name="max_veh_speed" value="$(arg max_veh_speed)" />
+  </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,6 @@
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>pacmod_msgs</depend>
+  <depend>pacmod3_msgs</depend>
   <depend>joy</depend>
 </package>

--- a/src/controllers.cpp
+++ b/src/controllers.cpp
@@ -7,7 +7,7 @@
 
 #include "pacmod_game_control/controllers.h"
 
-#include <pacmod_msgs/SystemCmdInt.h>
+#include <pacmod3_msgs/SystemCmdInt.h>
 
 // --- Generic gamepad controller (Logitech F310, XBOX)
 Controller::Controller()
@@ -71,21 +71,21 @@ int Controller::turn_signal_cmd()
   // Left on directional pad
   if (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] == AXES_MAX)
   {
-    return pacmod_msgs::SystemCmdInt::TURN_LEFT;
+    return pacmod3_msgs::SystemCmdInt::TURN_LEFT;
   }
   // Right on directional pad
   else if (input_msg_.axes[axes_[JoyAxis::DPAD_LR]] == AXES_MIN)
   {
-    return pacmod_msgs::SystemCmdInt::TURN_RIGHT;
+    return pacmod3_msgs::SystemCmdInt::TURN_RIGHT;
   }
   // Down on directional pad
   else if (input_msg_.axes[axes_[JoyAxis::DPAD_UD]] == AXES_MIN)
   {
-    return pacmod_msgs::SystemCmdInt::TURN_HAZARDS;
+    return pacmod3_msgs::SystemCmdInt::TURN_HAZARDS;
   }
   else
   {
-    return pacmod_msgs::SystemCmdInt::TURN_NONE;
+    return pacmod3_msgs::SystemCmdInt::TURN_NONE;
   }
 }
 
@@ -93,21 +93,21 @@ int Controller::shift_cmd()
 {
   uint8_t desired_gear = 0x0;
   desired_gear |=
-      (input_msg_.buttons[btns_[JoyButton::RIGHT_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_REVERSE |
-      (input_msg_.buttons[btns_[JoyButton::BOTTOM_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_HIGH |
-      (input_msg_.buttons[btns_[JoyButton::TOP_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_PARK |
-      (input_msg_.buttons[btns_[JoyButton::LEFT_BTN]] == BUTTON_DOWN) << pacmod_msgs::SystemCmdInt::SHIFT_NEUTRAL;
+      (input_msg_.buttons[btns_[JoyButton::RIGHT_BTN]] == BUTTON_DOWN) << pacmod3_msgs::SystemCmdInt::SHIFT_REVERSE |
+      (input_msg_.buttons[btns_[JoyButton::BOTTOM_BTN]] == BUTTON_DOWN) << pacmod3_msgs::SystemCmdInt::SHIFT_HIGH |
+      (input_msg_.buttons[btns_[JoyButton::TOP_BTN]] == BUTTON_DOWN) << pacmod3_msgs::SystemCmdInt::SHIFT_PARK |
+      (input_msg_.buttons[btns_[JoyButton::LEFT_BTN]] == BUTTON_DOWN) << pacmod3_msgs::SystemCmdInt::SHIFT_NEUTRAL;
 
   switch (desired_gear)
   {
-    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_REVERSE:
-      return pacmod_msgs::SystemCmdInt::SHIFT_REVERSE;
-    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_HIGH:
-      return pacmod_msgs::SystemCmdInt::SHIFT_HIGH;
-    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_PARK:
-      return pacmod_msgs::SystemCmdInt::SHIFT_PARK;
-    case 1 << pacmod_msgs::SystemCmdInt::SHIFT_NEUTRAL:
-      return pacmod_msgs::SystemCmdInt::SHIFT_NEUTRAL;
+    case 1 << pacmod3_msgs::SystemCmdInt::SHIFT_REVERSE:
+      return pacmod3_msgs::SystemCmdInt::SHIFT_REVERSE;
+    case 1 << pacmod3_msgs::SystemCmdInt::SHIFT_HIGH:
+      return pacmod3_msgs::SystemCmdInt::SHIFT_HIGH;
+    case 1 << pacmod3_msgs::SystemCmdInt::SHIFT_PARK:
+      return pacmod3_msgs::SystemCmdInt::SHIFT_PARK;
+    case 1 << pacmod3_msgs::SystemCmdInt::SHIFT_NEUTRAL:
+      return pacmod3_msgs::SystemCmdInt::SHIFT_NEUTRAL;
     // If we've got an invalid command (or multiple buttons pressed) return invalid
     default:
       return -1;
@@ -227,19 +227,19 @@ int HriSafeController::turn_signal_cmd()
 {
   if (input_msg_.axes[axes_[JoyAxis::RIGHT_STICK_UD]] < -0.5)
   {
-    return pacmod_msgs::SystemCmdInt::TURN_HAZARDS;
+    return pacmod3_msgs::SystemCmdInt::TURN_HAZARDS;
   }
   else if (input_msg_.axes[axes_[JoyAxis::RIGHT_STICK_LR]] > 0.5)
   {
-    return pacmod_msgs::SystemCmdInt::TURN_LEFT;
+    return pacmod3_msgs::SystemCmdInt::TURN_LEFT;
   }
   else if (input_msg_.axes[axes_[JoyAxis::RIGHT_STICK_LR]] < -0.5)
   {
-    return pacmod_msgs::SystemCmdInt::TURN_RIGHT;
+    return pacmod3_msgs::SystemCmdInt::TURN_RIGHT;
   }
   else
   {
-    return pacmod_msgs::SystemCmdInt::TURN_NONE;
+    return pacmod3_msgs::SystemCmdInt::TURN_NONE;
   }
 }
 

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -24,8 +24,8 @@ void PublishControl::init()
   enable_sub = n.subscribe("pacmod/enabled", 20, &PublishControl::callback_pacmod_enable, this);
   shift_sub = n.subscribe("pacmod/shift_rpt", 20, &PublishControl::callback_shift_rpt, this);
   turn_sub = n.subscribe("pacmod/turn_rpt", 20, &PublishControl::callback_turn_rpt, this);
-  lights_sub = n.subscribe("pacmod/headlight_rpt", 10, &PublishControl::callback_wiper_rpt, this);
-  horn_sub = n.subscribe("pacmod/horn_rpt", 10, &PublishControl::callback_wiper_rpt, this);
+  lights_sub = n.subscribe("pacmod/headlight_rpt", 10, &PublishControl::callback_lights_rpt, this);
+  horn_sub = n.subscribe("pacmod/horn_rpt", 10, &PublishControl::callback_horn_rpt, this);
   wiper_sub = n.subscribe("pacmod/wiper_rpt", 10, &PublishControl::callback_wiper_rpt, this);
 
   // Pubs
@@ -36,7 +36,7 @@ void PublishControl::init()
   wiper_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/wiper_cmd", 20);
   shift_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/shift_cmd", 20);
   accelerator_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdFloat>("pacmod/accel_cmd", 20);
-  steering_set_position_with_speed_limit_pub = n.advertise<pacmod3_msgs::SteeringCmd>("pacmod/steer_cmd", 20);
+  steering_set_position_with_speed_limit_pub = n.advertise<pacmod3_msgs::SteeringCmd>("pacmod/steering_cmd", 20);
   brake_set_position_pub = n.advertise<pacmod3_msgs::SystemCmdFloat>("pacmod/brake_cmd", 20);
 }
 

--- a/src/publish_control.cpp
+++ b/src/publish_control.cpp
@@ -20,29 +20,24 @@ void PublishControl::init()
 
   // Subs
   joy_sub = n.subscribe("joy", 1000, &PublishControl::callback_control, this);
-  speed_sub = n.subscribe("/pacmod/parsed_tx/vehicle_speed_rpt", 20, &PublishControl::callback_veh_speed, this);
-
-  enable_sub = n.subscribe("/pacmod/as_tx/enabled", 20, &PublishControl::callback_pacmod_enable, this);
-  shift_sub = n.subscribe("/pacmod/parsed_tx/shift_rpt", 20, &PublishControl::callback_shift_rpt, this);
-  turn_sub = n.subscribe("/pacmod/parsed_tx/turn_rpt", 20, &PublishControl::callback_turn_rpt, this);
-  rear_pass_door_sub =
-      n.subscribe("/pacmod/parsed_tx/rear_pass_door_rpt", 20, &PublishControl::callback_rear_pass_door_rpt, this);
-
-  lights_sub = n.subscribe("/pacmod/parsed_tx/headlight_rpt", 10, &PublishControl::callback_wiper_rpt, this);
-  horn_sub = n.subscribe("/pacmod/parsed_tx/horn_rpt", 10, &PublishControl::callback_wiper_rpt, this);
-  wiper_sub = n.subscribe("/pacmod/parsed_tx/wiper_rpt", 10, &PublishControl::callback_wiper_rpt, this);
+  speed_sub = n.subscribe("pacmod/vehicle_speed_rpt", 20, &PublishControl::callback_veh_speed, this);
+  enable_sub = n.subscribe("pacmod/enabled", 20, &PublishControl::callback_pacmod_enable, this);
+  shift_sub = n.subscribe("pacmod/shift_rpt", 20, &PublishControl::callback_shift_rpt, this);
+  turn_sub = n.subscribe("pacmod/turn_rpt", 20, &PublishControl::callback_turn_rpt, this);
+  lights_sub = n.subscribe("pacmod/headlight_rpt", 10, &PublishControl::callback_wiper_rpt, this);
+  horn_sub = n.subscribe("pacmod/horn_rpt", 10, &PublishControl::callback_wiper_rpt, this);
+  wiper_sub = n.subscribe("pacmod/wiper_rpt", 10, &PublishControl::callback_wiper_rpt, this);
 
   // Pubs
-  enable_pub = n.advertise<std_msgs::Bool>("/pacmod/as_rx/enable", 20);
-  turn_signal_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("/pacmod/as_rx/turn_cmd", 20);
-  rear_pass_door_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("/pacmod/as_rx/rear_pass_door_cmd", 20);
-  headlight_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("/pacmod/as_rx/headlight_cmd", 20);
-  horn_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdBool>("/pacmod/as_rx/horn_cmd", 20);
-  wiper_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("/pacmod/as_rx/wiper_cmd", 20);
-  shift_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("/pacmod/as_rx/shift_cmd", 20);
-  accelerator_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdFloat>("/pacmod/as_rx/accel_cmd", 20);
-  steering_set_position_with_speed_limit_pub = n.advertise<pacmod3_msgs::SteeringCmd>("/pacmod/as_rx/steer_cmd", 20);
-  brake_set_position_pub = n.advertise<pacmod3_msgs::SystemCmdFloat>("/pacmod/as_rx/brake_cmd", 20);
+  enable_pub = n.advertise<std_msgs::Bool>("pacmod/enable", 20);
+  turn_signal_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/turn_cmd", 20);
+  headlight_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/headlight_cmd", 20);
+  horn_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdBool>("pacmod/horn_cmd", 20);
+  wiper_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/wiper_cmd", 20);
+  shift_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/shift_cmd", 20);
+  accelerator_cmd_pub = n.advertise<pacmod3_msgs::SystemCmdFloat>("pacmod/accel_cmd", 20);
+  steering_set_position_with_speed_limit_pub = n.advertise<pacmod3_msgs::SteeringCmd>("pacmod/steer_cmd", 20);
+  brake_set_position_pub = n.advertise<pacmod3_msgs::SystemCmdFloat>("pacmod/brake_cmd", 20);
 }
 
 void PublishControl::callback_control(const sensor_msgs::Joy::ConstPtr& msg)
@@ -102,12 +97,6 @@ void PublishControl::callback_turn_rpt(const pacmod3_msgs::SystemRptInt::ConstPt
 {
   std::unique_lock<std::mutex> lock(turn_mutex);
   turn_signal_rpt = msg->output;
-}
-
-void PublishControl::callback_rear_pass_door_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg)
-{
-  std::unique_lock<std::mutex> lock(rear_pass_door_mutex);
-  last_rear_pass_door_cmd = msg->output;
 }
 
 void PublishControl::callback_lights_rpt(const pacmod3_msgs::SystemRptInt::ConstPtr& msg)


### PR DESCRIPTION
Resolves #80 by updating to the new pacmod3_msgs.

Tested today with ROS2 pacmod3 driver and ROS1 bridge.
Also updated the topic names and cleaned up a leftover `callback_rear_pass_door_rpt` subscriber.