### PR TITLE
[#124] Clear axes and button map in derived controller's constructor …

### DIFF
--- a/include/pacmod_game_control/controllers.h
+++ b/include/pacmod_game_control/controllers.h
@@ -14,10 +14,6 @@
 
 namespace controllers
 {
-const uint16_t BUTTON_PRESSED = 1;
-const uint16_t BUTTON_DEPRESSED = 0;
-const float AXES_MIN = -1.0;
-const float AXES_MAX = 1.0;
 
 enum class JoyAxis
 {
@@ -47,20 +43,10 @@ enum class JoyButton
   RIGHT_STICK_PUSH
 };
 
-struct EnumHash
-{
-  template <typename T>
-  std::size_t operator()(T t) const
-  {
-    return static_cast<std::size_t>(t);
-  }
-};
-
 class Controller
 {
 public:
-  Controller();
-  virtual ~Controller();
+  virtual ~Controller() = default;
   void set_controller_input(const sensor_msgs::msg::Joy& joy_msg);
   virtual float accelerator_value();
   virtual float brake_value();
@@ -76,8 +62,21 @@ public:
 protected:
   sensor_msgs::msg::Joy input_msg_;
   sensor_msgs::msg::Joy prev_input_msg_;
-  std::unordered_map<JoyAxis, int, EnumHash> axes_;
-  std::unordered_map<JoyButton, int, EnumHash> btns_;
+
+  // --- Generic gamepad controller (Logitech F310, XBOX)
+  std::unordered_map<JoyAxis, int> axes_ = {                                // NOLINT
+    { JoyAxis::LEFT_STICK_LR, 0 },     { JoyAxis::LEFT_STICK_UD, 1 },       // NOLINT
+    { JoyAxis::RIGHT_STICK_LR, 3 },    { JoyAxis::RIGHT_STICK_UD, 4 },      // NOLINT
+    { JoyAxis::LEFT_TRIGGER_AXIS, 2 }, { JoyAxis::RIGHT_TRIGGER_AXIS, 5 },  // NOLINT
+    { JoyAxis::DPAD_LR, 6 },           { JoyAxis::DPAD_UD, 7 }              // NOLINT
+  };
+                                                                          // NOLINT
+  std::unordered_map<JoyButton, int> btns_ = {                                                              // NOLINT
+    { JoyButton::BOTTOM_BTN, 0 },        { JoyButton::RIGHT_BTN, 1 },   { JoyButton::LEFT_BTN, 2 },         // NOLINT
+    { JoyButton::TOP_BTN, 3 },           { JoyButton::LEFT_BUMPER, 4 }, { JoyButton::RIGHT_BUMPER, 5 },     // NOLINT
+    { JoyButton::BACK_SELECT_MINUS, 6 }, { JoyButton::START_PLUS, 7 },  { JoyButton::LEFT_STICK_PUSH, 9 },  // NOLINT
+    { JoyButton::RIGHT_STICK_PUSH, 10 }                                                                     // NOLINT
+  };
 };
 
 class LogitechG29Controller : public Controller

--- a/src/controllers.cpp
+++ b/src/controllers.cpp
@@ -11,40 +11,13 @@
 
 namespace controllers
 {
-// --- Generic gamepad controller (Logitech F310, XBOX)
-Controller::Controller()
-{
-  axes_[JoyAxis::LEFT_STICK_LR] = 0;
-  axes_[JoyAxis::LEFT_STICK_UD] = 1;
 
-  axes_[JoyAxis::RIGHT_STICK_LR] = 3;
-  axes_[JoyAxis::RIGHT_STICK_UD] = 4;
-
-  axes_[JoyAxis::LEFT_TRIGGER_AXIS] = 2;
-  axes_[JoyAxis::RIGHT_TRIGGER_AXIS] = 5;
-
-  axes_[JoyAxis::DPAD_LR] = 6;
-  axes_[JoyAxis::DPAD_UD] = 7;
-
-  btns_[JoyButton::BOTTOM_BTN] = 0;
-  btns_[JoyButton::RIGHT_BTN] = 1;
-  btns_[JoyButton::LEFT_BTN] = 2;
-  btns_[JoyButton::TOP_BTN] = 3;
-
-  btns_[JoyButton::LEFT_BUMPER] = 4;
-  btns_[JoyButton::RIGHT_BUMPER] = 5;
-
-  btns_[JoyButton::BACK_SELECT_MINUS] = 6;
-  btns_[JoyButton::START_PLUS] = 7;
-
-  // Currently unused
-  btns_[JoyButton::LEFT_STICK_PUSH] = 9;
-  btns_[JoyButton::RIGHT_STICK_PUSH] = 10;
-}
-
-Controller::~Controller()
-{
-}
+namespace {
+const uint16_t BUTTON_PRESSED = 1;
+const uint16_t BUTTON_DEPRESSED = 0;
+const float AXES_MIN = -1.0;
+const float AXES_MAX = 1.0;
+}  // namespace
 
 void Controller::set_controller_input(const sensor_msgs::msg::Joy& joy_msg)
 {
@@ -154,6 +127,8 @@ bool Controller::disable()
 // --- Logitech G29, racing wheel with pedals
 LogitechG29Controller::LogitechG29Controller()
 {
+  axes_.clear();
+  btns_.clear();
   // steering wheel, not right stick
   axes_[JoyAxis::RIGHT_STICK_LR] = 0;
   // throttle pedal, not right trigger
@@ -191,6 +166,8 @@ float LogitechG29Controller::brake_value()
 // --- HRI Safe Remote Controller
 HriSafeController::HriSafeController()
 {
+  axes_.clear();
+  btns_.clear();
   axes_[JoyAxis::LEFT_STICK_LR] = 0;
   axes_[JoyAxis::LEFT_STICK_UD] = 1;
 


### PR DESCRIPTION
…first

- Remove user defined constructor for Controller.
- Remove Enumhash for unordered_map since the standard lib provides it.
- Move some const variables into an anonymous namespace.