### PR TITLE
New Hazard Lights Command

### DIFF
--- a/include/pacmod_game_control/controllers.h
+++ b/include/pacmod_game_control/controllers.h
@@ -54,6 +54,7 @@ public:
   virtual int shift_cmd();
   virtual bool horn_cmd();
   virtual bool headlight_change();
+  virtual bool hazards_cmd();
   virtual bool wiper_change();
   virtual bool enable();
   virtual bool disable();

--- a/include/pacmod_game_control/pacmod_game_control.h
+++ b/include/pacmod_game_control/pacmod_game_control.h
@@ -82,6 +82,7 @@ private:
   void PublishShifting();
   void PublishTurnSignal();
   void PublishLights();
+  void PublishHazards();
   void PublishHorn();
   void PublishWipers();
 
@@ -93,6 +94,7 @@ private:
 
   ros::Publisher turn_signal_cmd_pub_;
   ros::Publisher headlight_cmd_pub_;
+  ros::Publisher hazards_cmd_pub_;
   ros::Publisher horn_cmd_pub_;
   ros::Publisher wiper_cmd_pub_;
   ros::Publisher shift_cmd_pub_;
@@ -112,6 +114,7 @@ private:
   std::unique_ptr<controllers::Controller> controller_ = nullptr;
 
   bool lights_api_available_ = false;
+  bool hazards_available_ = false;
   bool horn_api_available_ = false;
   bool wiper_api_available_ = false;
 

--- a/include/pacmod_game_control/pacmod_game_control.h
+++ b/include/pacmod_game_control/pacmod_game_control.h
@@ -71,6 +71,7 @@ private:
   void ShiftRptCb(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
   void TurnRptCb(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
   void LightsRptCb(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
+  void HazardsRptCb(const pacmod3_msgs::SystemRptBool::ConstPtr& msg);
   void HornRptCb(const pacmod3_msgs::SystemRptBool::ConstPtr& msg);
   void WiperRptCb(const pacmod3_msgs::SystemRptInt::ConstPtr& msg);
 
@@ -106,6 +107,7 @@ private:
   ros::Subscriber speed_sub_;
   ros::Subscriber enable_sub_;
   ros::Subscriber lights_sub_;
+  ros::Subscriber hazards_sub_;
   ros::Subscriber horn_sub_;
   ros::Subscriber wiper_sub_;
 
@@ -114,7 +116,7 @@ private:
   std::unique_ptr<controllers::Controller> controller_ = nullptr;
 
   bool lights_api_available_ = false;
-  bool hazards_available_ = false;
+  bool hazards_api_available_ = false;
   bool horn_api_available_ = false;
   bool wiper_api_available_ = false;
 

--- a/src/controllers.cpp
+++ b/src/controllers.cpp
@@ -103,6 +103,13 @@ bool Controller::headlight_change()
           input_msg_.axes[axes_[JoyAxis::DPAD_UD]] == AXES_MAX);
 }
 
+bool Controller::hazards_cmd()
+{
+  // Down on directional pad. Only register a change when changing from depressed to pressed.
+  return (prev_input_msg_.axes[axes_[JoyAxis::DPAD_UD]] > AXES_MIN &&
+          input_msg_.axes[axes_[JoyAxis::DPAD_UD]] == AXES_MIN);
+}
+
 bool Controller::wiper_change()
 {
   // Only register a change when changing from depressed to pressed.

--- a/src/pacmod_game_control.cpp
+++ b/src/pacmod_game_control.cpp
@@ -21,6 +21,7 @@ void GameControl::Init()
   // Pubs
   turn_signal_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/turn_cmd", 20);
   headlight_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/headlight_cmd", 20);
+  hazards_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/hazard_lights_cmd", 20);
   horn_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdBool>("pacmod/horn_cmd", 20);
   wiper_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/wiper_cmd", 20);
   shift_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/shift_cmd", 20);
@@ -133,6 +134,7 @@ void GameControl::PublishCommands()
   PublishShifting();
   PublishTurnSignal();
   PublishLights();
+  PublishHazards();
   PublishHorn();
   PublishWipers();
 }
@@ -281,6 +283,22 @@ void GameControl::PublishLights()
 
   headlight_cmd_pub_msg.command = headlight_cmd_;
   headlight_cmd_pub_.publish(headlight_cmd_pub_msg);
+}
+
+void GameControl::PublishHazards()
+{
+  if (!hazards_available_)
+  {
+    return;
+  }
+
+  pacmod3_msgs::SystemCmdBool hazards_cmd_pub_msg;
+  hazards_cmd_pub_msg.enable = enable_cmd_;
+  hazards_cmd_pub_msg.clear_override = clear_override_cmd_;
+  hazards_cmd_pub_msg.ignore_overrides = false;
+
+  hazards_cmd_pub_msg.command = controller_->hazards_cmd();
+  hazards_cmd_pub_.publish(hazards_cmd_pub_msg);
 }
 
 void GameControl::PublishHorn()

--- a/src/pacmod_game_control.cpp
+++ b/src/pacmod_game_control.cpp
@@ -21,7 +21,7 @@ void GameControl::Init()
   // Pubs
   turn_signal_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/turn_cmd", 20);
   headlight_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/headlight_cmd", 20);
-  hazards_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/hazard_lights_cmd", 20);
+  hazards_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdBool>("pacmod/hazard_lights_cmd", 20);
   horn_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdBool>("pacmod/horn_cmd", 20);
   wiper_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/wiper_cmd", 20);
   shift_cmd_pub_ = nh_.advertise<pacmod3_msgs::SystemCmdInt>("pacmod/shift_cmd", 20);
@@ -34,6 +34,7 @@ void GameControl::Init()
   speed_sub_ = nh_.subscribe("pacmod/vehicle_speed_rpt", 20, &GameControl::VehicleSpeedCb, this);
   enable_sub_ = nh_.subscribe("pacmod/enabled", 20, &GameControl::PacmodEnabledCb, this);
   lights_sub_ = nh_.subscribe("pacmod/headlight_rpt", 10, &GameControl::LightsRptCb, this);
+  hazards_sub_ = nh_.subscribe("pacmod/hazard_lights_rpt", 10, &GameControl::HazardsRptCb, this);
   horn_sub_ = nh_.subscribe("pacmod/horn_rpt", 10, &GameControl::HornRptCb, this);
   wiper_sub_ = nh_.subscribe("pacmod/wiper_rpt", 10, &GameControl::WiperRptCb, this);
 }
@@ -104,6 +105,15 @@ void GameControl::LightsRptCb(const pacmod3_msgs::SystemRptInt::ConstPtr& msg)
   {
     lights_api_available_ = true;
     ROS_INFO("Headlights API detected");
+  }
+}
+
+void GameControl::HazardsRptCb(const pacmod3_msgs::SystemRptBool::ConstPtr& msg)
+{
+  if (!hazards_api_available_)
+  {
+    hazards_api_available_ = true;
+    ROS_INFO("Hazard Lights API detected");
   }
 }
 
@@ -287,7 +297,7 @@ void GameControl::PublishLights()
 
 void GameControl::PublishHazards()
 {
-  if (!hazards_available_)
+  if (!hazards_api_available_)
   {
     return;
   }


### PR DESCRIPTION
Part of #130, this adds ROS1 support for the newer hazard lights command. The previous hazard lights command (via turn signal command) has been left in place in case the user has an older pacmod.

Tested today in lexus, I remapped the turn signal command to make sure it was using the new dedicated command.

I will follow this up with a ROS2 PR as well.